### PR TITLE
Admin login auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,7 @@ SMTP_USER=your_mailtrap_user
 SMTP_PASS=your_mailtrap_pass
 SMTP_FROM=noreply@example.com
 
+INITIAL_SUPERADMIN_EMAIL=<admin_email>
+INITIAL_SUPERADMIN_TEMP_PASSWORD=<temp_password>
+
 APP_URL=http://localhost:3000

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,7 @@ module.exports = {
   collectCoverageFrom: [
     'src/modules/users/user.service.js',
     'src/modules/auth/auth.service.js',
+    'src/modules/admin-auth/admin-auth.service.js',
+    'src/modules/admins/admin.service.js',
   ],
 };

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const userRouter = require('./modules/users/user.routes');
 const authRouter = require('./modules/auth/auth.routes');
+const adminAuthRouter = require('./modules/admin-auth/admin-auth.routes');
+const adminRouter = require('./modules/admins/admin.routes');
 const { errorHandler } = require('./middlewares/errorHandler');
 
 const app = express();
@@ -13,6 +15,8 @@ app.get('/health', (_req, res) => {
 
 app.use('/api/users', userRouter);
 app.use('/api/auth', authRouter);
+app.use('/api/admin/auth', adminAuthRouter);
+app.use('/api/admin/admins', adminRouter);
 
 // Global error handler — must be last
 app.use(errorHandler);

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -21,6 +21,9 @@ const envSchema = z.object({
   JWT_EXPIRES_IN: z.string().default('7d'),
 
   ALLOWED_EMAIL_DOMAIN: z.string().optional(), // ej: "udesa.edu.ar"
+
+  INITIAL_SUPERADMIN_EMAIL: z.string().email().optional(),
+  INITIAL_SUPERADMIN_TEMP_PASSWORD: z.string().optional(),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -19,6 +19,8 @@ const envSchema = z.object({
 
   JWT_SECRET: z.string(),
   JWT_EXPIRES_IN: z.string().default('7d'),
+
+  ALLOWED_EMAIL_DOMAIN: z.string().optional(), // ej: "udesa.edu.ar"
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/src/config/mailer.js
+++ b/src/config/mailer.js
@@ -101,4 +101,28 @@ async function sendPasswordChangedEmail(toEmail) {
   });
 }
 
-module.exports = { sendVerificationEmail, sendResetPasswordEmail, sendPasswordChangedEmail };
+async function sendTempPasswordEmail(toEmail, tempPassword) {
+  if (!transporter) {
+    console.log('─────────────────────────────────────────────');
+    console.log('[DEV] Temp password email (not sent)');
+    console.log(`   To:       ${toEmail}`);
+    console.log(`   Password: ${tempPassword}`);
+    console.log('─────────────────────────────────────────────');
+    return;
+  }
+
+  await transporter.sendMail({
+    from: env.SMTP_FROM,
+    to: toEmail,
+    subject: 'Tu acceso al Backoffice de UdeSA-migos',
+    html: `
+      <h2>Bienvenido/a al panel de administración</h2>
+      <p>Se creó una cuenta de administrador para vos.</p>
+      <p>Tu contraseña temporal es: <strong>${tempPassword}</strong></p>
+      <p>Esta contraseña expira en <strong>24 horas</strong>. Al iniciar sesión serás redirigido/a para cambiarla.</p>
+      <p>Ingresá desde: <a href="${env.APP_URL}">${env.APP_URL}</a></p>
+    `,
+  });
+}
+
+module.exports = { sendVerificationEmail, sendResetPasswordEmail, sendPasswordChangedEmail, sendTempPasswordEmail };

--- a/src/db/migrations/002_create_admins.sql
+++ b/src/db/migrations/002_create_admins.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS admins (
+  id                       UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  email                    VARCHAR(255) NOT NULL,
+  password_hash            VARCHAR(255) NOT NULL,
+  role                     VARCHAR(20)  NOT NULL DEFAULT 'moderator', -- 'superadmin' | 'moderator'
+  must_change_password     BOOLEAN      NOT NULL DEFAULT TRUE,
+  temp_password_expires_at TIMESTAMPTZ,
+  failed_login_attempts    INT          NOT NULL DEFAULT 0,
+  locked_until             TIMESTAMPTZ,
+  token_version            INT          NOT NULL DEFAULT 1,
+  created_by               UUID         REFERENCES admins(id) ON DELETE SET NULL,
+  created_at               TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS admins_email_lower_idx ON admins (LOWER(email));

--- a/src/middlewares/authenticateAdmin.js
+++ b/src/middlewares/authenticateAdmin.js
@@ -1,0 +1,37 @@
+const jwt = require('jsonwebtoken');
+const { env } = require('../config/env');
+const { AppError } = require('./errorHandler');
+const { adminRepository } = require('../modules/admins/admin.repository');
+
+async function authenticateAdmin(req, _res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : null;
+
+  if (!token) {
+    return next(new AppError(401, 'Token de autenticación requerido'));
+  }
+
+  try {
+    const payload = jwt.verify(token, env.JWT_SECRET);
+
+    // Verifica que sea un token de admin (debe tener campo role)
+    if (!payload.role) {
+      return next(new AppError(403, 'Acceso denegado'));
+    }
+
+    // Verifica que la sesión no haya sido revocada
+    const admin = await adminRepository.findById(payload.sub);
+    if (!admin || admin.token_version !== payload.token_version) {
+      return next(new AppError(401, 'Sesión expirada o revocada. Iniciá sesión de nuevo.'));
+    }
+
+    req.admin = payload; // { sub, email, role, token_version, must_change_password }
+    next();
+  } catch {
+    next(new AppError(401, 'Token inválido o expirado'));
+  }
+}
+
+module.exports = { authenticateAdmin };

--- a/src/middlewares/authorize.js
+++ b/src/middlewares/authorize.js
@@ -1,0 +1,22 @@
+const { AppError } = require('./errorHandler');
+
+// Verifica que el admin tenga el rol requerido.
+// Uso: router.post('/admins', authenticateAdmin, authorize('superadmin'), ...)
+function authorize(requiredRole) {
+  return (req, _res, next) => {
+    if (req.admin.role !== requiredRole) {
+      return next(new AppError(403, 'No tenés permisos para realizar esta acción'));
+    }
+    next();
+  };
+}
+
+// Bloquea acceso si el admin todavía no cambió su contraseña temporal.
+function requirePasswordChanged(req, _res, next) {
+  if (req.admin.must_change_password) {
+    return next(new AppError(403, 'Debés cambiar tu contraseña temporal antes de continuar'));
+  }
+  next();
+}
+
+module.exports = { authorize, requirePasswordChanged };

--- a/src/modules/admin-auth/__tests__/admin-auth.service.test.js
+++ b/src/modules/admin-auth/__tests__/admin-auth.service.test.js
@@ -1,0 +1,228 @@
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { adminAuthService } = require('../admin-auth.service');
+const { adminRepository } = require('../../admins/admin.repository');
+const { sendPasswordChangedEmail } = require('../../../config/mailer');
+
+jest.mock('../../admins/admin.repository', () => ({
+  adminRepository: {
+    findByEmail: jest.fn(),
+    findById: jest.fn(),
+    incrementFailedAttempts: jest.fn(),
+    resetFailedAttempts: jest.fn(),
+    incrementTokenVersion: jest.fn(),
+    updatePassword: jest.fn(),
+  },
+}));
+
+jest.mock('../../../config/mailer', () => ({
+  sendPasswordChangedEmail: jest.fn(),
+}));
+
+jest.mock('../../../config/env', () => ({
+  env: { JWT_SECRET: 'test-secret', JWT_EXPIRES_IN: '8h' },
+}));
+
+jest.mock('bcryptjs');
+jest.mock('jsonwebtoken');
+
+const ADMIN_DB = {
+  id: 'admin-uuid-1',
+  email: 'admin@udesa.edu.ar',
+  password_hash: 'hashed_password',
+  role: 'superadmin',
+  must_change_password: false,
+  temp_password_expires_at: null,
+  locked_until: null,
+  token_version: 1,
+};
+
+const BLOQUEADO_HASTA = new Date(Date.now() + 30 * 60 * 1000);
+
+// login
+describe('adminAuthService.login', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    adminRepository.findByEmail.mockResolvedValue(ADMIN_DB);
+    bcrypt.compare.mockResolvedValue(true);
+    jwt.sign.mockReturnValue('jwt-token-mock');
+    adminRepository.resetFailedAttempts.mockResolvedValue();
+    adminRepository.incrementFailedAttempts.mockResolvedValue();
+  });
+
+  it('devuelve token y datos del admin cuando las credenciales son correctas', async () => {
+    const result = await adminAuthService.login({ email: 'admin@udesa.edu.ar', password: 'Password1' });
+
+    expect(result.token).toBe('jwt-token-mock');
+    expect(result.admin).toMatchObject({ id: 'admin-uuid-1', role: 'superadmin' });
+  });
+
+  it('normaliza el email a minúsculas antes de buscar', async () => {
+    await adminAuthService.login({ email: 'ADMIN@UDESA.EDU.AR', password: 'Password1' });
+
+    expect(adminRepository.findByEmail).toHaveBeenCalledWith('admin@udesa.edu.ar');
+  });
+
+  it('genera el JWT con el rol y must_change_password incluidos', async () => {
+    await adminAuthService.login({ email: 'admin@udesa.edu.ar', password: 'Password1' });
+
+    expect(jwt.sign).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'superadmin', must_change_password: false }),
+      'test-secret',
+      { expiresIn: '8h' }
+    );
+  });
+
+  it('resetea el contador de intentos fallidos al loguear exitosamente', async () => {
+    await adminAuthService.login({ email: 'admin@udesa.edu.ar', password: 'Password1' });
+
+    expect(adminRepository.resetFailedAttempts).toHaveBeenCalledWith('admin-uuid-1');
+  });
+
+  it('lanza error 401 genérico si el admin no existe', async () => {
+    adminRepository.findByEmail.mockResolvedValue(null);
+
+    await expect(
+      adminAuthService.login({ email: 'noexiste@udesa.edu.ar', password: 'Password1' })
+    ).rejects.toMatchObject({ statusCode: 401, message: 'Credenciales inválidas' });
+  });
+
+  it('lanza error 423 si la cuenta está bloqueada por intentos fallidos', async () => {
+    adminRepository.findByEmail.mockResolvedValue({ ...ADMIN_DB, locked_until: BLOQUEADO_HASTA });
+
+    await expect(
+      adminAuthService.login({ email: 'admin@udesa.edu.ar', password: 'Password1' })
+    ).rejects.toMatchObject({ statusCode: 423 });
+  });
+
+  it('lanza error 401 genérico si la contraseña es incorrecta', async () => {
+    bcrypt.compare.mockResolvedValue(false);
+
+    await expect(
+      adminAuthService.login({ email: 'admin@udesa.edu.ar', password: 'wrong' })
+    ).rejects.toMatchObject({ statusCode: 401, message: 'Credenciales inválidas' });
+  });
+
+  it('incrementa intentos fallidos con threshold 3 si la contraseña es incorrecta', async () => {
+    bcrypt.compare.mockResolvedValue(false);
+
+    await expect(adminAuthService.login({ email: 'admin@udesa.edu.ar', password: 'wrong' })).rejects.toThrow();
+    expect(adminRepository.incrementFailedAttempts).toHaveBeenCalledWith('admin-uuid-1', 3);
+  });
+
+  it('lanza error 403 si la contraseña temporal expiró', async () => {
+    const expirada = new Date(Date.now() - 60 * 1000);
+    adminRepository.findByEmail.mockResolvedValue({
+      ...ADMIN_DB,
+      must_change_password: true,
+      temp_password_expires_at: expirada,
+    });
+
+    await expect(
+      adminAuthService.login({ email: 'admin@udesa.edu.ar', password: 'Password1' })
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('permite login si must_change_password es true pero la contraseña NO expiró', async () => {
+    const vigente = new Date(Date.now() + 60 * 60 * 1000);
+    adminRepository.findByEmail.mockResolvedValue({
+      ...ADMIN_DB,
+      must_change_password: true,
+      temp_password_expires_at: vigente,
+    });
+
+    const result = await adminAuthService.login({ email: 'admin@udesa.edu.ar', password: 'Password1' });
+    expect(result.admin.must_change_password).toBe(true);
+  });
+});
+
+// logout
+describe('adminAuthService.logout', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('incrementa el token_version para revocar todas las sesiones', async () => {
+    adminRepository.incrementTokenVersion.mockResolvedValue();
+
+    await adminAuthService.logout('admin-uuid-1');
+
+    expect(adminRepository.incrementTokenVersion).toHaveBeenCalledWith('admin-uuid-1');
+  });
+
+  it('devuelve un mensaje de confirmación', async () => {
+    adminRepository.incrementTokenVersion.mockResolvedValue();
+
+    const result = await adminAuthService.logout('admin-uuid-1');
+
+    expect(result.message).toBeDefined();
+  });
+});
+
+// changePassword
+describe('adminAuthService.changePassword', () => {
+  const INPUT_VALIDO = { currentPassword: 'TempPass1', newPassword: 'NuevaPassword1' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    adminRepository.findById.mockResolvedValue(ADMIN_DB);
+    bcrypt.compare
+      .mockResolvedValueOnce(true)  // contraseña actual correcta
+      .mockResolvedValueOnce(false); // nueva contraseña ≠ anterior
+    bcrypt.hash.mockResolvedValue('nuevo-hash');
+    adminRepository.updatePassword.mockResolvedValue();
+    sendPasswordChangedEmail.mockResolvedValue();
+  });
+
+  it('actualiza la contraseña y limpia must_change_password', async () => {
+    await adminAuthService.changePassword('admin-uuid-1', INPUT_VALIDO);
+
+    expect(bcrypt.hash).toHaveBeenCalledWith('NuevaPassword1', 12);
+    expect(adminRepository.updatePassword).toHaveBeenCalledWith('admin-uuid-1', 'nuevo-hash');
+  });
+
+  it('envía email de notificación al cambiar la contraseña', async () => {
+    await adminAuthService.changePassword('admin-uuid-1', INPUT_VALIDO);
+    await Promise.resolve();
+
+    expect(sendPasswordChangedEmail).toHaveBeenCalledWith('admin@udesa.edu.ar');
+  });
+
+  it('no falla si el envío del email de notificación falla', async () => {
+    sendPasswordChangedEmail.mockRejectedValue(new Error('SMTP caído'));
+
+    await expect(adminAuthService.changePassword('admin-uuid-1', INPUT_VALIDO)).resolves.toBeDefined();
+  });
+
+  it('devuelve un mensaje de éxito', async () => {
+    const result = await adminAuthService.changePassword('admin-uuid-1', INPUT_VALIDO);
+
+    expect(result.message).toBeDefined();
+  });
+
+  it('lanza error 404 si el admin no existe', async () => {
+    adminRepository.findById.mockResolvedValue(null);
+
+    await expect(adminAuthService.changePassword('admin-uuid-1', INPUT_VALIDO))
+      .rejects.toMatchObject({ statusCode: 404 });
+    expect(adminRepository.updatePassword).not.toHaveBeenCalled();
+  });
+
+  it('lanza error 401 si la contraseña actual es incorrecta', async () => {
+    bcrypt.compare.mockReset();
+    bcrypt.compare.mockResolvedValue(false);
+
+    await expect(adminAuthService.changePassword('admin-uuid-1', INPUT_VALIDO))
+      .rejects.toMatchObject({ statusCode: 401 });
+    expect(adminRepository.updatePassword).not.toHaveBeenCalled();
+  });
+
+  it('lanza error 400 si la nueva contraseña es igual a la actual', async () => {
+    bcrypt.compare.mockReset();
+    bcrypt.compare
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+
+    await expect(adminAuthService.changePassword('admin-uuid-1', INPUT_VALIDO))
+      .rejects.toMatchObject({ statusCode: 400 });
+    expect(adminRepository.updatePassword).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/admin-auth/admin-auth.controller.js
+++ b/src/modules/admin-auth/admin-auth.controller.js
@@ -1,0 +1,32 @@
+const { adminAuthService } = require('./admin-auth.service');
+
+const adminAuthController = {
+  async login(req, res, next) {
+    try {
+      const result = await adminAuthService.login(req.body);
+      res.status(200).json({ message: 'Inicio de sesión exitoso.', ...result });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async logout(req, res, next) {
+    try {
+      const result = await adminAuthService.logout(req.admin.sub);
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async changePassword(req, res, next) {
+    try {
+      const result = await adminAuthService.changePassword(req.admin.sub, req.body);
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+};
+
+module.exports = { adminAuthController };

--- a/src/modules/admin-auth/admin-auth.routes.js
+++ b/src/modules/admin-auth/admin-auth.routes.js
@@ -1,0 +1,19 @@
+const { Router } = require('express');
+const { adminAuthController } = require('./admin-auth.controller');
+const { validate } = require('../../middlewares/validate');
+const { authenticateAdmin } = require('../../middlewares/authenticateAdmin');
+const { loginSchema, changePasswordSchema } = require('./admin-auth.schemas');
+
+const router = Router();
+
+// POST /api/admin/auth/login — H2
+router.post('/login', validate(loginSchema), adminAuthController.login);
+
+// POST /api/admin/auth/logout
+router.post('/logout', authenticateAdmin, adminAuthController.logout);
+
+// POST /api/admin/auth/change-password — H1 CA.1
+// Solo requiere authenticateAdmin, NO requirePasswordChanged (es justamente para cumplirlo)
+router.post('/change-password', authenticateAdmin, validate(changePasswordSchema), adminAuthController.changePassword);
+
+module.exports = router;

--- a/src/modules/admin-auth/admin-auth.schemas.js
+++ b/src/modules/admin-auth/admin-auth.schemas.js
@@ -1,0 +1,31 @@
+const { z } = require('zod');
+
+const loginSchema = z.object({
+  email: z
+    .string({ required_error: 'El email es obligatorio' })
+    .email('El formato del email no es válido'),
+
+  password: z
+    .string({ required_error: 'La contraseña es obligatoria' })
+    .min(1, 'La contraseña es obligatoria'),
+});
+
+const changePasswordSchema = z.object({
+  currentPassword: z
+    .string({ required_error: 'La contraseña actual es obligatoria' })
+    .min(1, 'La contraseña actual es obligatoria'),
+
+  newPassword: z
+    .string({ required_error: 'La nueva contraseña es obligatoria' })
+    .min(8, 'La nueva contraseña debe tener al menos 8 caracteres')
+    .regex(/[A-Z]/, 'La nueva contraseña debe tener al menos una letra mayúscula')
+    .regex(/[0-9]/, 'La nueva contraseña debe tener al menos un número'),
+
+  confirmPassword: z
+    .string({ required_error: 'La confirmación de contraseña es obligatoria' }),
+}).refine((data) => data.newPassword === data.confirmPassword, {
+  message: 'Las contraseñas no coinciden',
+  path: ['confirmPassword'],
+});
+
+module.exports = { loginSchema, changePasswordSchema };

--- a/src/modules/admin-auth/admin-auth.service.js
+++ b/src/modules/admin-auth/admin-auth.service.js
@@ -1,0 +1,98 @@
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { adminRepository } = require('../admins/admin.repository');
+const { sendPasswordChangedEmail } = require('../../config/mailer');
+const { AppError } = require('../../middlewares/errorHandler');
+const { env } = require('../../config/env');
+
+// H2 CA.3: 3 intentos fallidos → 30 minutos de bloqueo
+const LOGIN_MAX_ATTEMPTS = 3;
+
+const adminAuthService = {
+  // H2: Login de administrador
+  async login({ email, password }) {
+    const admin = await adminRepository.findByEmail(email.toLowerCase());
+
+    if (!admin) {
+      throw new AppError(401, 'Credenciales inválidas');
+    }
+
+    // H2 CA.3: verificar bloqueo por intentos fallidos
+    if (admin.locked_until && new Date(admin.locked_until) > new Date()) {
+      const mins = Math.ceil((new Date(admin.locked_until) - new Date()) / 60000);
+      throw new AppError(423, `Cuenta bloqueada temporalmente. Intentá de nuevo en ${mins} minutos.`);
+    }
+
+    const passwordMatch = await bcrypt.compare(password, admin.password_hash);
+    if (!passwordMatch) {
+      await adminRepository.incrementFailedAttempts(admin.id, LOGIN_MAX_ATTEMPTS);
+      throw new AppError(401, 'Credenciales inválidas');
+    }
+
+    // H1 CA.3: contraseña temporal expirada → no dejar entrar
+    if (admin.must_change_password && admin.temp_password_expires_at) {
+      if (new Date(admin.temp_password_expires_at) < new Date()) {
+        throw new AppError(403, 'Tu contraseña temporal expiró. Contactá al SuperAdmin para obtener una nueva.');
+      }
+    }
+
+    await adminRepository.resetFailedAttempts(admin.id);
+
+    // H2 CA.1: JWT con rol incluido
+    const token = jwt.sign(
+      {
+        sub: admin.id,
+        email: admin.email,
+        role: admin.role,
+        token_version: admin.token_version,
+        must_change_password: admin.must_change_password,
+      },
+      env.JWT_SECRET,
+      { expiresIn: env.JWT_EXPIRES_IN }
+    );
+
+    return {
+      token,
+      admin: {
+        id: admin.id,
+        email: admin.email,
+        role: admin.role,
+        must_change_password: admin.must_change_password,
+      },
+    };
+  },
+
+  async logout(adminId) {
+    await adminRepository.incrementTokenVersion(adminId);
+    return { message: 'Sesión cerrada exitosamente.' };
+  },
+
+  // H1 CA.1: cambio de contraseña forzado en primer login
+  async changePassword(adminId, { currentPassword, newPassword }) {
+    const admin = await adminRepository.findById(adminId);
+    if (!admin) {
+      throw new AppError(404, 'Administrador no encontrado');
+    }
+
+    const passwordMatch = await bcrypt.compare(currentPassword, admin.password_hash);
+    if (!passwordMatch) {
+      throw new AppError(401, 'La contraseña actual es incorrecta');
+    }
+
+    const isSamePassword = await bcrypt.compare(newPassword, admin.password_hash);
+    if (isSamePassword) {
+      throw new AppError(400, 'La nueva contraseña no puede ser igual a la anterior');
+    }
+
+    const newPasswordHash = await bcrypt.hash(newPassword, 12);
+    await adminRepository.updatePassword(adminId, newPasswordHash);
+
+    sendPasswordChangedEmail(admin.email).catch((err) =>
+      console.error('Failed to send password changed email:', err)
+    );
+
+    return { message: 'Contraseña actualizada exitosamente. Por favor, iniciá sesión de nuevo.' };
+  },
+};
+
+module.exports = { adminAuthService };

--- a/src/modules/admins/__tests__/admin.service.test.js
+++ b/src/modules/admins/__tests__/admin.service.test.js
@@ -1,0 +1,171 @@
+const bcrypt = require('bcryptjs');
+const { adminService } = require('../admin.service');
+const { adminRepository } = require('../admin.repository');
+const { sendTempPasswordEmail } = require('../../../config/mailer');
+const { env } = require('../../../config/env');
+
+jest.mock('../admin.repository', () => ({
+  adminRepository: {
+    findByEmail: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+    updateTempPassword: jest.fn(),
+  },
+}));
+
+jest.mock('../../../config/mailer', () => ({
+  sendTempPasswordEmail: jest.fn(),
+}));
+
+jest.mock('../../../config/env', () => ({ env: { ALLOWED_EMAIL_DOMAIN: undefined } }));
+
+jest.mock('bcryptjs');
+jest.mock('uuid', () => ({ v4: () => 'aaaabbbbccccddddeeeeffffgggghhhh' }));
+
+const ADMIN_DB = {
+  id: 'admin-uuid-2',
+  email: 'mod@udesa.edu.ar',
+  role: 'moderator',
+  must_change_password: true,
+  created_at: new Date().toISOString(),
+};
+
+// createAdmin
+describe('adminService.createAdmin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    adminRepository.findByEmail.mockResolvedValue(null);
+    adminRepository.create.mockResolvedValue(ADMIN_DB);
+    bcrypt.hash.mockResolvedValue('hashed-temp-password');
+    sendTempPasswordEmail.mockResolvedValue();
+  });
+
+  it('crea el admin y devuelve sus datos con la contraseña temporal', async () => {
+    const result = await adminService.createAdmin(
+      { email: 'mod@udesa.edu.ar', role: 'moderator' },
+      'superadmin-uuid'
+    );
+
+    expect(adminRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'mod@udesa.edu.ar', role: 'moderator' })
+    );
+    expect(result.temp_password).toBeDefined();
+    expect(result.temp_password_expires_at).toBeDefined();
+  });
+
+  it('hashea la contraseña temporal con bcrypt', async () => {
+    await adminService.createAdmin(
+      { email: 'mod@udesa.edu.ar', role: 'moderator' },
+      'superadmin-uuid'
+    );
+
+    expect(bcrypt.hash).toHaveBeenCalledWith(expect.any(String), 12);
+  });
+
+  it('envía email con la contraseña temporal (fire-and-forget)', async () => {
+    await adminService.createAdmin(
+      { email: 'mod@udesa.edu.ar', role: 'moderator' },
+      'superadmin-uuid'
+    );
+    await Promise.resolve();
+
+    expect(sendTempPasswordEmail).toHaveBeenCalledWith(
+      'mod@udesa.edu.ar',
+      expect.any(String)
+    );
+  });
+
+  it('no falla si el envío del email falla', async () => {
+    sendTempPasswordEmail.mockRejectedValue(new Error('SMTP caído'));
+
+    await expect(
+      adminService.createAdmin({ email: 'mod@udesa.edu.ar', role: 'moderator' }, 'superadmin-uuid')
+    ).resolves.toBeDefined();
+  });
+
+  it('lanza error 409 si el email ya está en uso', async () => {
+    adminRepository.findByEmail.mockResolvedValue(ADMIN_DB);
+
+    await expect(
+      adminService.createAdmin({ email: 'mod@udesa.edu.ar', role: 'moderator' }, 'superadmin-uuid')
+    ).rejects.toMatchObject({ statusCode: 409 });
+    expect(adminRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('lanza error 400 si el email no pertenece al dominio permitido', async () => {
+    env.ALLOWED_EMAIL_DOMAIN = 'udesa.edu.ar';
+
+    await expect(
+      adminService.createAdmin({ email: 'mod@gmail.com', role: 'moderator' }, 'superadmin-uuid')
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(adminRepository.create).not.toHaveBeenCalled();
+
+    env.ALLOWED_EMAIL_DOMAIN = undefined;
+  });
+
+  it('acepta el email si pertenece al dominio permitido', async () => {
+    env.ALLOWED_EMAIL_DOMAIN = 'udesa.edu.ar';
+
+    const result = await adminService.createAdmin(
+      { email: 'mod@udesa.edu.ar', role: 'moderator' },
+      'superadmin-uuid'
+    );
+
+    expect(result).toBeDefined();
+    env.ALLOWED_EMAIL_DOMAIN = undefined;
+  });
+});
+
+// resetAdminPassword
+describe('adminService.resetAdminPassword', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    adminRepository.findById.mockResolvedValue(ADMIN_DB);
+    adminRepository.updateTempPassword.mockResolvedValue();
+    bcrypt.hash.mockResolvedValue('hashed-temp-password');
+    sendTempPasswordEmail.mockResolvedValue();
+  });
+
+  it('regenera la contraseña temporal y la devuelve', async () => {
+    const result = await adminService.resetAdminPassword('admin-uuid-2', 'superadmin-uuid');
+
+    expect(adminRepository.updateTempPassword).toHaveBeenCalledWith(
+      'admin-uuid-2',
+      'hashed-temp-password',
+      expect.any(Date)
+    );
+    expect(result.temp_password).toBeDefined();
+    expect(result.message).toBeDefined();
+  });
+
+  it('envía email con la nueva contraseña temporal', async () => {
+    await adminService.resetAdminPassword('admin-uuid-2', 'superadmin-uuid');
+    await Promise.resolve();
+
+    expect(sendTempPasswordEmail).toHaveBeenCalledWith('mod@udesa.edu.ar', expect.any(String));
+  });
+
+  it('lanza error 404 si el admin no existe', async () => {
+    adminRepository.findById.mockResolvedValue(null);
+
+    await expect(
+      adminService.resetAdminPassword('admin-uuid-2', 'superadmin-uuid')
+    ).rejects.toMatchObject({ statusCode: 404 });
+    expect(adminRepository.updateTempPassword).not.toHaveBeenCalled();
+  });
+
+  it('lanza error 400 si intenta resetear su propia contraseña', async () => {
+    await expect(
+      adminService.resetAdminPassword('admin-uuid-2', 'admin-uuid-2')
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(adminRepository.updateTempPassword).not.toHaveBeenCalled();
+  });
+
+  it('no falla si el envío del email falla en resetAdminPassword', async () => {
+    sendTempPasswordEmail.mockRejectedValue(new Error('SMTP caído'));
+
+    await expect(
+      adminService.resetAdminPassword('admin-uuid-2', 'superadmin-uuid')
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/modules/admins/admin.controller.js
+++ b/src/modules/admins/admin.controller.js
@@ -1,0 +1,26 @@
+const { adminService } = require('./admin.service');
+
+const adminController = {
+  async create(req, res, next) {
+    try {
+      const admin = await adminService.createAdmin(req.body, req.admin.sub);
+      res.status(201).json({
+        message: 'Administrador creado exitosamente. Se envió la contraseña temporal por email.',
+        admin,
+      });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async resetPassword(req, res, next) {
+    try {
+      const result = await adminService.resetAdminPassword(req.params.id, req.admin.sub);
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+};
+
+module.exports = { adminController };

--- a/src/modules/admins/admin.repository.js
+++ b/src/modules/admins/admin.repository.js
@@ -1,0 +1,87 @@
+const { query } = require('../../config/database');
+
+const adminRepository = {
+  async findByEmail(email) {
+    const result = await query(
+      'SELECT * FROM admins WHERE LOWER(email) = LOWER($1)',
+      [email]
+    );
+    return result.rows[0] ?? null;
+  },
+
+  async findById(id) {
+    const result = await query(
+      'SELECT * FROM admins WHERE id = $1',
+      [id]
+    );
+    return result.rows[0] ?? null;
+  },
+
+  async create({ email, passwordHash, role, tempPasswordExpiresAt, createdBy }) {
+    const result = await query(
+      `INSERT INTO admins (email, password_hash, role, must_change_password, temp_password_expires_at, created_by)
+       VALUES (LOWER($1), $2, $3, TRUE, $4, $5)
+       RETURNING id, email, role, must_change_password, created_at`,
+      [email, passwordHash, role, tempPasswordExpiresAt, createdBy ?? null]
+    );
+    return result.rows[0];
+  },
+
+  async incrementFailedAttempts(adminId, threshold) {
+    await query(
+      `UPDATE admins
+       SET failed_login_attempts = failed_login_attempts + 1,
+           locked_until = CASE
+             WHEN failed_login_attempts + 1 >= $1 THEN NOW() + INTERVAL '30 minutes'
+             ELSE locked_until
+           END,
+           updated_at = NOW()
+       WHERE id = $2`,
+      [threshold, adminId]
+    );
+  },
+
+  async resetFailedAttempts(adminId) {
+    await query(
+      `UPDATE admins
+       SET failed_login_attempts = 0, locked_until = NULL, updated_at = NOW()
+       WHERE id = $1`,
+      [adminId]
+    );
+  },
+
+  async incrementTokenVersion(adminId) {
+    await query(
+      `UPDATE admins SET token_version = token_version + 1, updated_at = NOW() WHERE id = $1`,
+      [adminId]
+    );
+  },
+
+  async updatePassword(adminId, passwordHash) {
+    await query(
+      `UPDATE admins
+       SET password_hash = $1,
+           must_change_password = FALSE,
+           temp_password_expires_at = NULL,
+           token_version = token_version + 1,
+           updated_at = NOW()
+       WHERE id = $2`,
+      [passwordHash, adminId]
+    );
+  },
+
+  async updateTempPassword(adminId, passwordHash, expiresAt) {
+    await query(
+      `UPDATE admins
+       SET password_hash = $1,
+           must_change_password = TRUE,
+           temp_password_expires_at = $2,
+           token_version = token_version + 1,
+           updated_at = NOW()
+       WHERE id = $3`,
+      [passwordHash, expiresAt, adminId]
+    );
+  },
+};
+
+module.exports = { adminRepository };

--- a/src/modules/admins/admin.routes.js
+++ b/src/modules/admins/admin.routes.js
@@ -1,0 +1,19 @@
+const { Router } = require('express');
+const { adminController } = require('./admin.controller');
+const { validate } = require('../../middlewares/validate');
+const { authenticateAdmin } = require('../../middlewares/authenticateAdmin');
+const { authorize, requirePasswordChanged } = require('../../middlewares/authorize');
+const { createAdminSchema } = require('./admin.schemas');
+
+const router = Router();
+
+// Todas las rutas requieren: estar logueado + haber cambiado la contraseña + ser SuperAdmin
+router.use(authenticateAdmin, requirePasswordChanged, authorize('superadmin'));
+
+// POST /api/admin/admins — H1: crear nuevo administrador
+router.post('/', validate(createAdminSchema), adminController.create);
+
+// POST /api/admin/admins/:id/reset-password — H1 CA.3: regenerar contraseña temporal expirada
+router.post('/:id/reset-password', adminController.resetPassword);
+
+module.exports = router;

--- a/src/modules/admins/admin.schemas.js
+++ b/src/modules/admins/admin.schemas.js
@@ -1,0 +1,14 @@
+const { z } = require('zod');
+
+const createAdminSchema = z.object({
+  email: z
+    .string({ required_error: 'El email es obligatorio' })
+    .email('El formato del email no es válido'),
+
+  role: z.enum(['superadmin', 'moderator'], {
+    required_error: 'El rol es obligatorio',
+    invalid_type_error: "El rol debe ser 'superadmin' o 'moderator'",
+  }),
+});
+
+module.exports = { createAdminSchema };

--- a/src/modules/admins/admin.service.js
+++ b/src/modules/admins/admin.service.js
@@ -1,0 +1,88 @@
+const bcrypt = require('bcryptjs');
+const { v4: uuidv4 } = require('uuid');
+const { adminRepository } = require('./admin.repository');
+const { sendTempPasswordEmail } = require('../../config/mailer');
+const { AppError } = require('../../middlewares/errorHandler');
+const { env } = require('../../config/env');
+
+const TEMP_PASSWORD_EXPIRY_HOURS = 24;
+
+function tempPasswordExpiresAt() {
+  const date = new Date();
+  date.setHours(date.getHours() + TEMP_PASSWORD_EXPIRY_HOURS);
+  return date;
+}
+
+function generateTempPassword() {
+  return uuidv4().replace(/-/g, '').slice(0, 10);
+}
+
+const adminService = {
+  // H1: SuperAdmin crea un nuevo administrador
+  async createAdmin({ email, role }, createdById) {
+    // CA.4: validar dominio de email si está configurado
+    if (env.ALLOWED_EMAIL_DOMAIN) {
+      if (!email.toLowerCase().endsWith(`@${env.ALLOWED_EMAIL_DOMAIN}`)) {
+        throw new AppError(400, `El email debe pertenecer al dominio @${env.ALLOWED_EMAIL_DOMAIN}`);
+      }
+    }
+
+    const existing = await adminRepository.findByEmail(email);
+    if (existing) {
+      throw new AppError(409, 'Ya existe un administrador con ese email');
+    }
+
+    // CA.1: contraseña temporal + forzar cambio en primer login
+    const tempPassword = generateTempPassword();
+    const passwordHash = await bcrypt.hash(tempPassword, 12);
+    const expiresAt = tempPasswordExpiresAt();
+
+    const admin = await adminRepository.create({
+      email,
+      passwordHash,
+      role,
+      tempPasswordExpiresAt: expiresAt,
+      createdBy: createdById,
+    });
+
+    sendTempPasswordEmail(email, tempPassword).catch((err) =>
+      console.error('Failed to send temp password email:', err)
+    );
+
+    return {
+      ...admin,
+      temp_password: tempPassword,
+      temp_password_expires_at: expiresAt,
+    };
+  },
+
+  // H1 CA.3: SuperAdmin regenera contraseña temporal expirada
+  async resetAdminPassword(targetAdminId, requestingAdminId) {
+    const admin = await adminRepository.findById(targetAdminId);
+    if (!admin) {
+      throw new AppError(404, 'Administrador no encontrado');
+    }
+
+    if (targetAdminId === requestingAdminId) {
+      throw new AppError(400, 'Usá el endpoint de cambio de contraseña para tu propia cuenta');
+    }
+
+    const tempPassword = generateTempPassword();
+    const passwordHash = await bcrypt.hash(tempPassword, 12);
+    const expiresAt = tempPasswordExpiresAt();
+
+    await adminRepository.updateTempPassword(targetAdminId, passwordHash, expiresAt);
+
+    sendTempPasswordEmail(admin.email, tempPassword).catch((err) =>
+      console.error('Failed to send temp password email:', err)
+    );
+
+    return {
+      message: 'Contraseña temporal regenerada exitosamente.',
+      temp_password: tempPassword,
+      temp_password_expires_at: expiresAt,
+    };
+  },
+};
+
+module.exports = { adminService };

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 
 const fs = require('fs');
 const path = require('path');
+const bcrypt = require('bcryptjs');
 const { env } = require('./config/env');
 const { pool } = require('./config/database');
 const app = require('./app');
@@ -17,8 +18,28 @@ async function runMigrations() {
   }
 }
 
+async function seedInitialSuperAdmin() {
+  if (!env.INITIAL_SUPERADMIN_EMAIL || !env.INITIAL_SUPERADMIN_TEMP_PASSWORD) return;
+
+  const { rows } = await pool.query('SELECT COUNT(*) FROM admins');
+  if (parseInt(rows[0].count, 10) > 0) return;
+
+  const passwordHash = await bcrypt.hash(env.INITIAL_SUPERADMIN_TEMP_PASSWORD, 12);
+  const expiresAt = new Date();
+  expiresAt.setHours(expiresAt.getHours() + 24);
+
+  await pool.query(
+    `INSERT INTO admins (email, password_hash, role, must_change_password, temp_password_expires_at)
+     VALUES (LOWER($1), $2, 'superadmin', TRUE, $3)`,
+    [env.INITIAL_SUPERADMIN_EMAIL, passwordHash, expiresAt]
+  );
+
+  console.log(`SuperAdmin inicial creado: ${env.INITIAL_SUPERADMIN_EMAIL}`);
+}
+
 async function start() {
   await runMigrations();
+  await seedInitialSuperAdmin();
 
   const port = parseInt(env.PORT, 10);
   app.listen(port, () => {


### PR DESCRIPTION
@MateoCostantini @Tomicarrie @glewit 

Incorporo la autenticación y gestión de administradores del backoffice directamente en el servicio users, centralizando toda la lógica de autenticación del sistema en un único lugar. Los admins se modelan en una tabla separada (admins) en lugar de extender users porque tienen campos y reglas de negocio propios: contraseña temporal con expiración de 24hs (H1 CA.3), cambio forzado en el primer login (H1 CA.1), roles (superadmin/moderator) con permisos diferenciados (H1 CA.2) y creación por parte de otro admin en lugar de autorregistro. Mezclarlos en la misma tabla hubiera dejado columnas irrelevantes para el 99% de los registros y aumentado el riesgo de que bugs en la lógica de admins afecten a usuarios regulares. Se agregan los endpoints POST /api/admin/auth/login (H2), POST /api/admin/auth/logout, POST /api/admin/auth/change-password (H1 CA.1), POST /api/admin/admins (H1) y POST /api/admin/admins/reset-password (H1 CA.3), junto con sus tests unitarios.

Valide manuualmente con Postman y todo parece estar funcionando bien a priori. 

Si mantenemos esta decision de tener los admins enn una tabla separada, no va a hacer falta tener el rol en la tabla de users ni poner ese rol en el jwt (de hecho la validacion que se esta haciendo ahora para evitar que un usuario tenga acceso al backoffice es que no haya rol en el jwt. Si no vamos a tener que cambiar esa logica tmb.