### PR TITLE
Deuda recnica refresh access token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,8 @@ INITIAL_SUPERADMIN_EMAIL=<admin_email>
 INITIAL_SUPERADMIN_TEMP_PASSWORD=<temp_password>
 
 APP_URL=http://localhost:3000
+
+JWT_SECRET=una_clave_secreta_muy_larga_y_segura_cambiar_en_produccion
+JWT_EXPIRES_IN=7d
+ACCESS_TOKEN_EXPIRES_IN=15m
+REFRESH_TOKEN_EXPIRES_IN=7d

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
+        "cookie-parser": "^1.4.7",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
@@ -2180,6 +2181,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.7",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const cookieParser = require('cookie-parser');
 const userRouter = require('./modules/users/user.routes');
 const authRouter = require('./modules/auth/auth.routes');
 const adminAuthRouter = require('./modules/admin-auth/admin-auth.routes');
@@ -8,6 +9,7 @@ const { errorHandler } = require('./middlewares/errorHandler');
 const app = express();
 
 app.use(express.json());
+app.use(cookieParser());
 
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -13,4 +13,20 @@ async function query(text, params) {
   return pool.query(text, params);
 }
 
-module.exports = { pool, query };
+// Ejecuta fn(client) dentro de una transacción; hace rollback automático si lanza.
+async function withTransaction(fn) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const result = await fn(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+module.exports = { pool, query, withTransaction };

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -19,6 +19,8 @@ const envSchema = z.object({
 
   JWT_SECRET: z.string(),
   JWT_EXPIRES_IN: z.string().default('7d'),
+  ACCESS_TOKEN_EXPIRES_IN: z.string().default('15m'),
+  REFRESH_TOKEN_EXPIRES_IN: z.string().default('7d'),
 
   ALLOWED_EMAIL_DOMAIN: z.string().optional(), // ej: "udesa.edu.ar"
 

--- a/src/db/migrations/001_create_users.sql
+++ b/src/db/migrations/001_create_users.sql
@@ -32,9 +32,7 @@ CREATE TABLE IF NOT EXISTS preferences (
   id                        UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id                   UUID        NOT NULL UNIQUE,
   search_radius_km          INT         NOT NULL DEFAULT 25,
-  search_radius_min         INT         NOT NULL DEFAULT 1,
-  search_radius_max         INT         NOT NULL DEFAULT 50,
-  location_update_frequency INT         NOT NULL DEFAULT 5, -- 5 | 15 | 30 -- deberiamos agregar un constraint aca no?
+  location_update_frequency INT         NOT NULL DEFAULT 5, 
   created_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   biography   TEXT,

--- a/src/db/migrations/003_create_refresh_tokens.sql
+++ b/src/db/migrations/003_create_refresh_tokens.sql
@@ -1,0 +1,19 @@
+CREATE TABLE user_refresh_tokens (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_hash VARCHAR(64)  NOT NULL UNIQUE, -- SHA-256 hex del token opaco
+  expires_at TIMESTAMPTZ  NOT NULL,
+  created_at TIMESTAMPTZ  DEFAULT NOW()
+);
+
+CREATE INDEX user_refresh_tokens_user_id_idx ON user_refresh_tokens(user_id);
+
+CREATE TABLE admin_refresh_tokens (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  admin_id   UUID         NOT NULL REFERENCES admins(id) ON DELETE CASCADE,
+  token_hash VARCHAR(64)  NOT NULL UNIQUE, -- SHA-256 hex del token opaco
+  expires_at TIMESTAMPTZ  NOT NULL,
+  created_at TIMESTAMPTZ  DEFAULT NOW()
+);
+
+CREATE INDEX admin_refresh_tokens_admin_id_idx ON admin_refresh_tokens(admin_id);

--- a/src/middlewares/authenticate.js
+++ b/src/middlewares/authenticate.js
@@ -15,7 +15,7 @@ async function authenticate(req, res, next) {
 
   try {
     const payload = jwt.verify(token, env.JWT_SECRET);
-    
+
     // CA.7: Verify session is not revoked (token_version must match)
     const user = await userRepository.findById(payload.sub);
 

--- a/src/middlewares/authenticateInternal.js
+++ b/src/middlewares/authenticateInternal.js
@@ -1,0 +1,12 @@
+const { env } = require('../config/env');
+const { AppError } = require('./errorHandler');
+
+function authenticateInternal(req, _res, next) {
+  const secret = req.headers['x-internal-secret'];
+  if (!secret || secret !== env.INTERNAL_SECRET) {
+    return next(new AppError(403, 'Forbidden'));
+  }
+  next();
+}
+
+module.exports = { authenticateInternal };

--- a/src/modules/admin-auth/__tests__/admin-auth.service.test.js
+++ b/src/modules/admin-auth/__tests__/admin-auth.service.test.js
@@ -1,5 +1,6 @@
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
+const { v4: uuidv4 } = require('uuid');
 const { adminAuthService } = require('../admin-auth.service');
 const { adminRepository } = require('../../admins/admin.repository');
 const { sendPasswordChangedEmail } = require('../../../config/mailer');
@@ -12,6 +13,10 @@ jest.mock('../../admins/admin.repository', () => ({
     resetFailedAttempts: jest.fn(),
     incrementTokenVersion: jest.fn(),
     updatePassword: jest.fn(),
+    createRefreshToken: jest.fn(),
+    rotateRefreshToken: jest.fn(),
+    deleteRefreshToken: jest.fn(),
+    deleteAllRefreshTokensForAdmin: jest.fn(),
   },
 }));
 
@@ -20,11 +25,12 @@ jest.mock('../../../config/mailer', () => ({
 }));
 
 jest.mock('../../../config/env', () => ({
-  env: { JWT_SECRET: 'test-secret', JWT_EXPIRES_IN: '8h' },
+  env: { JWT_SECRET: 'test-secret', ACCESS_TOKEN_EXPIRES_IN: '15m', REFRESH_TOKEN_EXPIRES_IN: '7d' },
 }));
 
 jest.mock('bcryptjs');
 jest.mock('jsonwebtoken');
+jest.mock('uuid');
 
 const ADMIN_DB = {
   id: 'admin-uuid-1',
@@ -40,37 +46,52 @@ const ADMIN_DB = {
 const BLOQUEADO_HASTA = new Date(Date.now() + 30 * 60 * 1000);
 
 // login
+
 describe('adminAuthService.login', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     adminRepository.findByEmail.mockResolvedValue(ADMIN_DB);
     bcrypt.compare.mockResolvedValue(true);
-    jwt.sign.mockReturnValue('jwt-token-mock');
+    jwt.sign.mockReturnValue('access-token-mock');
+    uuidv4.mockReturnValue('refresh-uuid-mock');
     adminRepository.resetFailedAttempts.mockResolvedValue();
     adminRepository.incrementFailedAttempts.mockResolvedValue();
+    adminRepository.createRefreshToken.mockResolvedValue();
   });
 
-  it('devuelve token y datos del admin cuando las credenciales son correctas', async () => {
+  it('devuelve accessToken, refreshToken y datos del admin cuando las credenciales son correctas', async () => {
     const result = await adminAuthService.login({ email: 'admin@udesa.edu.ar', password: 'Password1' });
 
-    expect(result.token).toBe('jwt-token-mock');
+    expect(result.accessToken).toBe('access-token-mock');
+    expect(result.refreshToken).toBe('refresh-uuid-mock');
     expect(result.admin).toMatchObject({ id: 'admin-uuid-1', role: 'superadmin' });
+  });
+
+  it('guarda el refresh token opaco en la BD', async () => {
+    await adminAuthService.login({ email: 'admin@udesa.edu.ar', password: 'Password1' });
+
+    expect(adminRepository.createRefreshToken).toHaveBeenCalledWith(
+      'admin-uuid-1',
+      'refresh-uuid-mock',
+      expect.any(Date)
+    );
+  });
+
+  it('genera el access token JWT con el rol incluido', async () => {
+    await adminAuthService.login({ email: 'admin@udesa.edu.ar', password: 'Password1' });
+
+    expect(jwt.sign).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'superadmin', must_change_password: false, type: 'access' }),
+      'test-secret',
+      { expiresIn: '15m' }
+    );
+    expect(jwt.sign).toHaveBeenCalledTimes(1);
   });
 
   it('normaliza el email a minúsculas antes de buscar', async () => {
     await adminAuthService.login({ email: 'ADMIN@UDESA.EDU.AR', password: 'Password1' });
 
     expect(adminRepository.findByEmail).toHaveBeenCalledWith('admin@udesa.edu.ar');
-  });
-
-  it('genera el JWT con el rol y must_change_password incluidos', async () => {
-    await adminAuthService.login({ email: 'admin@udesa.edu.ar', password: 'Password1' });
-
-    expect(jwt.sign).toHaveBeenCalledWith(
-      expect.objectContaining({ role: 'superadmin', must_change_password: false }),
-      'test-secret',
-      { expiresIn: '8h' }
-    );
   });
 
   it('resetea el contador de intentos fallidos al loguear exitosamente', async () => {
@@ -137,27 +158,95 @@ describe('adminAuthService.login', () => {
 });
 
 // logout
+
 describe('adminAuthService.logout', () => {
-  beforeEach(() => jest.clearAllMocks());
-
-  it('incrementa el token_version para revocar todas las sesiones', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    adminRepository.deleteRefreshToken.mockResolvedValue();
     adminRepository.incrementTokenVersion.mockResolvedValue();
+  });
 
-    await adminAuthService.logout('admin-uuid-1');
+  it('incrementa el token_version para invalidar el access token inmediatamente', async () => {
+    await adminAuthService.logout('admin-uuid-1', 'some-refresh-token');
 
     expect(adminRepository.incrementTokenVersion).toHaveBeenCalledWith('admin-uuid-1');
   });
 
-  it('devuelve un mensaje de confirmación', async () => {
-    adminRepository.incrementTokenVersion.mockResolvedValue();
+  it('borra el refresh token específico de la BD', async () => {
+    await adminAuthService.logout('admin-uuid-1', 'some-refresh-token');
 
-    const result = await adminAuthService.logout('admin-uuid-1');
+    expect(adminRepository.deleteRefreshToken).toHaveBeenCalledWith('some-refresh-token');
+  });
+
+  it('funciona sin refresh token (no falla si la cookie no estaba)', async () => {
+    await adminAuthService.logout('admin-uuid-1');
+
+    expect(adminRepository.deleteRefreshToken).not.toHaveBeenCalled();
+    expect(adminRepository.incrementTokenVersion).toHaveBeenCalledWith('admin-uuid-1');
+  });
+
+  it('devuelve un mensaje de confirmación', async () => {
+    const result = await adminAuthService.logout('admin-uuid-1', 'some-refresh-token');
 
     expect(result.message).toBeDefined();
   });
 });
 
+// refreshToken
+
+describe('adminAuthService.refreshToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    adminRepository.rotateRefreshToken.mockResolvedValue('admin-uuid-1');
+    adminRepository.findById.mockResolvedValue(ADMIN_DB);
+    uuidv4.mockReturnValue('new-refresh-uuid');
+    jwt.sign.mockReturnValue('new-access-token-mock');
+  });
+
+  it('devuelve nuevo accessToken y newRefreshToken cuando el token es válido', async () => {
+    const result = await adminAuthService.refreshToken('valid-uuid-token');
+
+    expect(result.accessToken).toBe('new-access-token-mock');
+    expect(result.newRefreshToken).toBe('new-refresh-uuid');
+  });
+
+  it('genera el access token JWT con el rol del admin', async () => {
+    await adminAuthService.refreshToken('valid-uuid-token');
+
+    expect(jwt.sign).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: 'admin-uuid-1', role: 'superadmin', type: 'access' }),
+      'test-secret',
+      { expiresIn: '15m' }
+    );
+  });
+
+  it('delega la rotación atómica al repositorio con el token viejo y el nuevo', async () => {
+    await adminAuthService.refreshToken('old-uuid-token');
+
+    expect(adminRepository.rotateRefreshToken).toHaveBeenCalledWith(
+      'old-uuid-token',
+      'new-refresh-uuid',
+      expect.any(Date)
+    );
+  });
+
+  it('lanza error 401 si el token no existe, expiró o ya fue usado (race condition)', async () => {
+    adminRepository.rotateRefreshToken.mockResolvedValue(null);
+
+    await expect(adminAuthService.refreshToken('used-or-expired-token'))
+      .rejects.toMatchObject({ statusCode: 401 });
+  });
+
+  it('lanza error 401 si el admin no existe', async () => {
+    adminRepository.findById.mockResolvedValue(null);
+
+    await expect(adminAuthService.refreshToken('valid-uuid-token'))
+      .rejects.toMatchObject({ statusCode: 401 });
+  });
+});
+
 // changePassword
+
 describe('adminAuthService.changePassword', () => {
   const INPUT_VALIDO = { currentPassword: 'TempPass1', newPassword: 'NuevaPassword1' };
 
@@ -165,10 +254,11 @@ describe('adminAuthService.changePassword', () => {
     jest.clearAllMocks();
     adminRepository.findById.mockResolvedValue(ADMIN_DB);
     bcrypt.compare
-      .mockResolvedValueOnce(true)  // contraseña actual correcta
-      .mockResolvedValueOnce(false); // nueva contraseña ≠ anterior
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
     bcrypt.hash.mockResolvedValue('nuevo-hash');
     adminRepository.updatePassword.mockResolvedValue();
+    adminRepository.deleteAllRefreshTokensForAdmin.mockResolvedValue();
     sendPasswordChangedEmail.mockResolvedValue();
   });
 
@@ -177,6 +267,12 @@ describe('adminAuthService.changePassword', () => {
 
     expect(bcrypt.hash).toHaveBeenCalledWith('NuevaPassword1', 12);
     expect(adminRepository.updatePassword).toHaveBeenCalledWith('admin-uuid-1', 'nuevo-hash');
+  });
+
+  it('elimina todos los refresh tokens del admin al cambiar contraseña', async () => {
+    await adminAuthService.changePassword('admin-uuid-1', INPUT_VALIDO);
+
+    expect(adminRepository.deleteAllRefreshTokensForAdmin).toHaveBeenCalledWith('admin-uuid-1');
   });
 
   it('envía email de notificación al cambiar la contraseña', async () => {

--- a/src/modules/admin-auth/admin-auth.controller.js
+++ b/src/modules/admin-auth/admin-auth.controller.js
@@ -1,10 +1,42 @@
 const { adminAuthService } = require('./admin-auth.service');
+const { env } = require('../../config/env');
+
+const REFRESH_COOKIE_NAME = 'adminRefreshToken';
+
+function getRefreshCookieOptions() {
+  const isProduction = env.APP_URL.startsWith('https');
+  return {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: isProduction ? 'None' : 'Lax',
+    path: '/api/admin/auth',
+    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days in ms
+  };
+}
 
 const adminAuthController = {
   async login(req, res, next) {
     try {
-      const result = await adminAuthService.login(req.body);
-      res.status(200).json({ message: 'Inicio de sesión exitoso.', ...result });
+      const { accessToken, refreshToken, admin } = await adminAuthService.login(req.body);
+
+      res.cookie(REFRESH_COOKIE_NAME, refreshToken, getRefreshCookieOptions());
+
+      res.status(200).json({ message: 'Inicio de sesión exitoso.', accessToken, admin });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async refresh(req, res, next) {
+    try {
+      const token = req.cookies[REFRESH_COOKIE_NAME];
+      if (!token) {
+        return res.status(401).json({ error: 'Refresh token requerido' });
+      }
+
+      const { accessToken, newRefreshToken } = await adminAuthService.refreshToken(token);
+      res.cookie(REFRESH_COOKIE_NAME, newRefreshToken, getRefreshCookieOptions());
+      res.status(200).json({ accessToken });
     } catch (err) {
       next(err);
     }
@@ -12,7 +44,9 @@ const adminAuthController = {
 
   async logout(req, res, next) {
     try {
-      const result = await adminAuthService.logout(req.admin.sub);
+      const refreshToken = req.cookies[REFRESH_COOKIE_NAME];
+      const result = await adminAuthService.logout(req.admin.sub, refreshToken);
+      res.clearCookie(REFRESH_COOKIE_NAME, { path: '/api/admin/auth' });
       res.status(200).json(result);
     } catch (err) {
       next(err);
@@ -22,6 +56,7 @@ const adminAuthController = {
   async changePassword(req, res, next) {
     try {
       const result = await adminAuthService.changePassword(req.admin.sub, req.body);
+      res.clearCookie(REFRESH_COOKIE_NAME, { path: '/api/admin/auth' });
       res.status(200).json(result);
     } catch (err) {
       next(err);

--- a/src/modules/admin-auth/admin-auth.routes.js
+++ b/src/modules/admin-auth/admin-auth.routes.js
@@ -9,6 +9,9 @@ const router = Router();
 // POST /api/admin/auth/login — H2
 router.post('/login', validate(loginSchema), adminAuthController.login);
 
+// POST /api/admin/auth/refresh — get new access token using refresh token cookie
+router.post('/refresh', adminAuthController.refresh);
+
 // POST /api/admin/auth/logout
 router.post('/logout', authenticateAdmin, adminAuthController.logout);
 

--- a/src/modules/admin-auth/admin-auth.service.js
+++ b/src/modules/admin-auth/admin-auth.service.js
@@ -1,3 +1,4 @@
+const { v4: uuidv4 } = require('uuid');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const { adminRepository } = require('../admins/admin.repository');
@@ -7,6 +8,7 @@ const { env } = require('../../config/env');
 
 // H2 CA.3: 3 intentos fallidos → 30 minutos de bloqueo
 const LOGIN_MAX_ATTEMPTS = 3;
+const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 const adminAuthService = {
   // H2: Login de administrador
@@ -38,21 +40,28 @@ const adminAuthService = {
 
     await adminRepository.resetFailedAttempts(admin.id);
 
-    // H2 CA.1: JWT con rol incluido
-    const token = jwt.sign(
+    // H2 CA.1: access token JWT (corta duración)
+    const accessToken = jwt.sign(
       {
         sub: admin.id,
         email: admin.email,
         role: admin.role,
         token_version: admin.token_version,
         must_change_password: admin.must_change_password,
+        type: 'access',
       },
       env.JWT_SECRET,
-      { expiresIn: env.JWT_EXPIRES_IN }
+      { expiresIn: env.ACCESS_TOKEN_EXPIRES_IN }
     );
 
+    // Refresh token opaco (UUID) guardado en BD
+    const refreshToken = uuidv4();
+    const refreshExpiresAt = new Date(Date.now() + REFRESH_TOKEN_TTL_MS);
+    await adminRepository.createRefreshToken(admin.id, refreshToken, refreshExpiresAt);
+
     return {
-      token,
+      accessToken,
+      refreshToken,
       admin: {
         id: admin.id,
         email: admin.email,
@@ -62,7 +71,42 @@ const adminAuthService = {
     };
   },
 
-  async logout(adminId) {
+  async refreshToken(currentRefreshToken) {
+    const newRefreshToken = uuidv4();
+    const refreshExpiresAt = new Date(Date.now() + REFRESH_TOKEN_TTL_MS);
+
+    // Rotación atómica en transacción: invalida el token viejo y crea el nuevo en un solo paso.
+    const adminId = await adminRepository.rotateRefreshToken(currentRefreshToken, newRefreshToken, refreshExpiresAt);
+    if (!adminId) {
+      throw new AppError(401, 'Refresh token inválido o expirado');
+    }
+
+    const admin = await adminRepository.findById(adminId);
+    if (!admin) {
+      throw new AppError(401, 'Sesión revocada. Por favor, iniciá sesión de nuevo.');
+    }
+
+    const accessToken = jwt.sign(
+      {
+        sub: admin.id,
+        email: admin.email,
+        role: admin.role,
+        token_version: admin.token_version,
+        must_change_password: admin.must_change_password,
+        type: 'access',
+      },
+      env.JWT_SECRET,
+      { expiresIn: env.ACCESS_TOKEN_EXPIRES_IN }
+    );
+
+    return { accessToken, newRefreshToken };
+  },
+
+  async logout(adminId, refreshToken = null) {
+    if (refreshToken) {
+      await adminRepository.deleteRefreshToken(refreshToken);
+    }
+    // Invalida el access token actual inmediatamente
     await adminRepository.incrementTokenVersion(adminId);
     return { message: 'Sesión cerrada exitosamente.' };
   },
@@ -86,6 +130,7 @@ const adminAuthService = {
 
     const newPasswordHash = await bcrypt.hash(newPassword, 12);
     await adminRepository.updatePassword(adminId, newPasswordHash);
+    await adminRepository.deleteAllRefreshTokensForAdmin(adminId);
 
     sendPasswordChangedEmail(admin.email).catch((err) =>
       console.error('Failed to send password changed email:', err)

--- a/src/modules/admins/admin.repository.js
+++ b/src/modules/admins/admin.repository.js
@@ -1,4 +1,5 @@
-const { query } = require('../../config/database');
+const { query, withTransaction } = require('../../config/database');
+const { hashToken } = require('../../utils/tokenHash');
 
 const adminRepository = {
   async findByEmail(email) {
@@ -68,6 +69,43 @@ const adminRepository = {
        WHERE id = $2`,
       [passwordHash, adminId]
     );
+  },
+
+  async createRefreshToken(adminId, token, expiresAt) {
+    await query(
+      `INSERT INTO admin_refresh_tokens (admin_id, token_hash, expires_at) VALUES ($1, $2, $3)`,
+      [adminId, hashToken(token), expiresAt]
+    );
+  },
+
+  async rotateRefreshToken(oldToken, newToken, expiresAt) {
+    const oldHash = hashToken(oldToken);
+    const newHash = hashToken(newToken);
+
+    return withTransaction(async (client) => {
+      const { rows } = await client.query(
+        `DELETE FROM admin_refresh_tokens WHERE token_hash = $1 AND expires_at > NOW() RETURNING admin_id`,
+        [oldHash]
+      );
+
+      if (rows.length === 0) return null;
+
+      const { admin_id } = rows[0];
+      await client.query(
+        `INSERT INTO admin_refresh_tokens (admin_id, token_hash, expires_at) VALUES ($1, $2, $3)`,
+        [admin_id, newHash, expiresAt]
+      );
+
+      return admin_id;
+    });
+  },
+
+  async deleteRefreshToken(token) {
+    await query(`DELETE FROM admin_refresh_tokens WHERE token_hash = $1`, [hashToken(token)]);
+  },
+
+  async deleteAllRefreshTokensForAdmin(adminId) {
+    await query(`DELETE FROM admin_refresh_tokens WHERE admin_id = $1`, [adminId]);
   },
 
   async updateTempPassword(adminId, passwordHash, expiresAt) {

--- a/src/modules/auth/__tests__/auth.service.test.js
+++ b/src/modules/auth/__tests__/auth.service.test.js
@@ -4,7 +4,6 @@ const { v4: uuidv4 } = require('uuid');
 const { authService } = require('../auth.service');
 const { userRepository } = require('../../users/user.repository');
 const { sendResetPasswordEmail, sendPasswordChangedEmail } = require('../../../config/mailer');
-const { AppError } = require('../../../middlewares/errorHandler');
 
 jest.mock('../../users/user.repository', () => ({
   userRepository: {
@@ -18,6 +17,10 @@ jest.mock('../../users/user.repository', () => ({
     updatePasswordResetToken: jest.fn(),
     updateLastResetRequest: jest.fn(),
     updatePasswordAndInvalidateResetToken: jest.fn(),
+    createRefreshToken: jest.fn(),
+    rotateRefreshToken: jest.fn(),
+    deleteRefreshToken: jest.fn(),
+    deleteAllRefreshTokensForUser: jest.fn(),
   },
 }));
 
@@ -26,16 +29,13 @@ jest.mock('../../../config/mailer', () => ({
   sendPasswordChangedEmail: jest.fn(),
 }));
 
-// env.js llama process.exit si no hay variables de entorno, lo mockeamos
 jest.mock('../../../config/env', () => ({
-  env: { JWT_SECRET: 'test-secret', JWT_EXPIRES_IN: '7d' },
+  env: { JWT_SECRET: 'test-secret', ACCESS_TOKEN_EXPIRES_IN: '15m', REFRESH_TOKEN_EXPIRES_IN: '7d' },
 }));
 
 jest.mock('bcryptjs');
 jest.mock('jsonwebtoken');
 jest.mock('uuid');
-
-// Datos de prueba
 
 const USUARIO_DB = {
   id: 'user-uuid-1',
@@ -51,10 +51,9 @@ const USUARIO_DB = {
   created_at: new Date('2024-01-01'),
 };
 
-// Fecha en el futuro para simular cuenta bloqueada
 const BLOQUEADO_HASTA = new Date(Date.now() + 15 * 60 * 1000);
 
-// login 
+// login
 
 describe('authService.login', () => {
   beforeEach(() => {
@@ -62,16 +61,40 @@ describe('authService.login', () => {
     userRepository.findByEmail.mockResolvedValue(USUARIO_DB);
     userRepository.findByUsername.mockResolvedValue(USUARIO_DB);
     bcrypt.compare.mockResolvedValue(true);
-    jwt.sign.mockReturnValue('jwt-token-mock');
+    jwt.sign.mockReturnValue('access-token-mock');
+    uuidv4.mockReturnValue('refresh-uuid-mock');
     userRepository.resetFailedAttempts.mockResolvedValue();
     userRepository.incrementFailedAttempts.mockResolvedValue();
+    userRepository.createRefreshToken.mockResolvedValue();
   });
 
-  it('devuelve token y datos del usuario cuando las credenciales son correctas', async () => {
+  it('devuelve accessToken, refreshToken y datos del usuario cuando las credenciales son correctas', async () => {
     const result = await authService.login({ identifier: 'test@example.com', password: 'Password1' });
 
-    expect(result.token).toBe('jwt-token-mock');
+    expect(result.accessToken).toBe('access-token-mock');
+    expect(result.refreshToken).toBe('refresh-uuid-mock');
     expect(result.user).toMatchObject({ id: 'user-uuid-1', username: 'testuser' });
+  });
+
+  it('guarda el refresh token opaco en la BD', async () => {
+    await authService.login({ identifier: 'test@example.com', password: 'Password1' });
+
+    expect(userRepository.createRefreshToken).toHaveBeenCalledWith(
+      'user-uuid-1',
+      'refresh-uuid-mock',
+      expect.any(Date)
+    );
+  });
+
+  it('genera el access token JWT con los datos del usuario', async () => {
+    await authService.login({ identifier: 'test@example.com', password: 'Password1' });
+
+    expect(jwt.sign).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: 'user-uuid-1', username: 'testuser', token_version: 1, type: 'access' }),
+      'test-secret',
+      { expiresIn: '15m' }
+    );
+    expect(jwt.sign).toHaveBeenCalledTimes(1);
   });
 
   it('busca por email cuando el identifier contiene @', async () => {
@@ -86,16 +109,6 @@ describe('authService.login', () => {
 
     expect(userRepository.findByUsername).toHaveBeenCalledWith('testuser');
     expect(userRepository.findByEmail).not.toHaveBeenCalled();
-  });
-
-  it('genera el JWT con los datos del usuario', async () => {
-    await authService.login({ identifier: 'test@example.com', password: 'Password1' });
-
-    expect(jwt.sign).toHaveBeenCalledWith(
-      expect.objectContaining({ sub: 'user-uuid-1', username: 'testuser', token_version: 1 }),
-      'test-secret',
-      { expiresIn: '7d' }
-    );
   });
 
   it('resetea el contador de intentos fallidos al loguear correctamente', async () => {
@@ -160,29 +173,42 @@ describe('authService.login', () => {
   });
 });
 
-// logout 
+// logout
 
 describe('authService.logout', () => {
-  beforeEach(() => jest.clearAllMocks());
-
-  it('incrementa el token_version para revocar todas las sesiones activas', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    userRepository.deleteRefreshToken.mockResolvedValue();
     userRepository.incrementTokenVersion.mockResolvedValue();
+  });
 
-    await authService.logout('user-uuid-1');
+  it('incrementa el token_version para invalidar el access token inmediatamente', async () => {
+    await authService.logout('user-uuid-1', 'some-refresh-token');
 
     expect(userRepository.incrementTokenVersion).toHaveBeenCalledWith('user-uuid-1');
   });
 
-  it('devuelve un mensaje de confirmación', async () => {
-    userRepository.incrementTokenVersion.mockResolvedValue();
+  it('borra el refresh token específico de la BD', async () => {
+    await authService.logout('user-uuid-1', 'some-refresh-token');
 
-    const result = await authService.logout('user-uuid-1');
+    expect(userRepository.deleteRefreshToken).toHaveBeenCalledWith('some-refresh-token');
+  });
+
+  it('funciona sin refresh token (no falla si la cookie no estaba)', async () => {
+    await authService.logout('user-uuid-1');
+
+    expect(userRepository.deleteRefreshToken).not.toHaveBeenCalled();
+    expect(userRepository.incrementTokenVersion).toHaveBeenCalledWith('user-uuid-1');
+  });
+
+  it('devuelve un mensaje de confirmación', async () => {
+    const result = await authService.logout('user-uuid-1', 'some-refresh-token');
 
     expect(result.message).toBeDefined();
   });
 });
 
-// requestPasswordReset 
+// requestPasswordReset
 
 describe('authService.requestPasswordReset', () => {
   beforeEach(() => {
@@ -213,7 +239,7 @@ describe('authService.requestPasswordReset', () => {
   });
 
   it('devuelve mensaje genérico si el usuario está en throttle (menos de 1 min)', async () => {
-    const hacePocoTiempo = new Date(Date.now() - 30 * 1000); // hace 30 segundos
+    const hacePocoTiempo = new Date(Date.now() - 30 * 1000);
     userRepository.findByEmail.mockResolvedValue({ ...USUARIO_DB, last_reset_request_at: hacePocoTiempo });
 
     const result = await authService.requestPasswordReset('test@example.com');
@@ -247,7 +273,7 @@ describe('authService.requestPasswordReset', () => {
     userRepository.findByEmail.mockResolvedValue(USUARIO_DB);
 
     await authService.requestPasswordReset('test@example.com');
-    await Promise.resolve(); // espera 
+    await Promise.resolve();
 
     expect(sendResetPasswordEmail).toHaveBeenCalledWith('test@example.com', 'reset-token-uuid');
   });
@@ -271,7 +297,7 @@ describe('authService.requestPasswordReset', () => {
   });
 });
 
-// verifyResetToken 
+// verifyResetToken
 
 describe('authService.verifyResetToken', () => {
   beforeEach(() => jest.clearAllMocks());
@@ -297,7 +323,7 @@ describe('authService.verifyResetToken', () => {
   });
 });
 
-// resetPassword 
+// resetPassword
 
 describe('authService.resetPassword', () => {
   const INPUT_VALIDO = {
@@ -309,19 +335,23 @@ describe('authService.resetPassword', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     userRepository.findByPasswordResetToken.mockResolvedValue(USUARIO_DB);
-    bcrypt.compare.mockResolvedValue(false); // nueva contraseña ≠ anterior por defecto
+    bcrypt.compare.mockResolvedValue(false);
     bcrypt.hash.mockResolvedValue('nuevo-hash');
     userRepository.updatePasswordAndInvalidateResetToken.mockResolvedValue();
+    userRepository.deleteAllRefreshTokensForUser.mockResolvedValue();
   });
 
-  it('actualiza la contraseña y invalida el token cuando todo es válido', async () => {
+  it('actualiza la contraseña e invalida el token cuando todo es válido', async () => {
     await authService.resetPassword(INPUT_VALIDO);
 
     expect(bcrypt.hash).toHaveBeenCalledWith('NuevaPassword1', 12);
-    expect(userRepository.updatePasswordAndInvalidateResetToken).toHaveBeenCalledWith(
-      'user-uuid-1',
-      'nuevo-hash'
-    );
+    expect(userRepository.updatePasswordAndInvalidateResetToken).toHaveBeenCalledWith('user-uuid-1', 'nuevo-hash');
+  });
+
+  it('revoca todas las sesiones activas al resetear la contraseña (H5 CA.7)', async () => {
+    await authService.resetPassword(INPUT_VALIDO);
+
+    expect(userRepository.deleteAllRefreshTokensForUser).toHaveBeenCalledWith('user-uuid-1');
   });
 
   it('devuelve un mensaje de éxito', async () => {
@@ -345,14 +375,82 @@ describe('authService.resetPassword', () => {
   });
 
   it('lanza error 400 si la nueva contraseña es igual a la anterior', async () => {
-    bcrypt.compare.mockResolvedValue(true); // misma contraseña
+    bcrypt.compare.mockResolvedValue(true);
 
     await expect(authService.resetPassword(INPUT_VALIDO)).rejects.toMatchObject({ statusCode: 400 });
     expect(userRepository.updatePasswordAndInvalidateResetToken).not.toHaveBeenCalled();
   });
 });
 
-// changePassword 
+// refreshToken
+
+describe('authService.refreshToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    userRepository.rotateRefreshToken.mockResolvedValue('user-uuid-1');
+    userRepository.findById.mockResolvedValue(USUARIO_DB);
+    uuidv4.mockReturnValue('new-refresh-uuid');
+    jwt.sign.mockReturnValue('new-access-token-mock');
+  });
+
+  it('devuelve nuevo accessToken y newRefreshToken cuando el token es válido', async () => {
+    const result = await authService.refreshToken('valid-uuid-token');
+
+    expect(result.accessToken).toBe('new-access-token-mock');
+    expect(result.newRefreshToken).toBe('new-refresh-uuid');
+  });
+
+  it('genera el access token JWT con los datos del usuario', async () => {
+    await authService.refreshToken('valid-uuid-token');
+
+    expect(jwt.sign).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: 'user-uuid-1', type: 'access' }),
+      'test-secret',
+      { expiresIn: '15m' }
+    );
+  });
+
+  it('delega la rotación atómica al repositorio con el token viejo y el nuevo', async () => {
+    await authService.refreshToken('old-uuid-token');
+
+    expect(userRepository.rotateRefreshToken).toHaveBeenCalledWith(
+      'old-uuid-token',
+      'new-refresh-uuid',
+      expect.any(Date)
+    );
+  });
+
+  it('lanza error 401 si el token no existe, expiró o ya fue usado (race condition)', async () => {
+    userRepository.rotateRefreshToken.mockResolvedValue(null);
+
+    await expect(authService.refreshToken('used-or-expired-token'))
+      .rejects.toMatchObject({ statusCode: 401 });
+  });
+
+  it('lanza error 401 si el usuario no existe', async () => {
+    userRepository.findById.mockResolvedValue(null);
+
+    await expect(authService.refreshToken('valid-uuid-token'))
+      .rejects.toMatchObject({ statusCode: 401 });
+  });
+
+  it('lanza error 403 si la cuenta fue eliminada (soft-delete)', async () => {
+    userRepository.findById.mockResolvedValue({ ...USUARIO_DB, deleted_at: new Date() });
+
+    await expect(authService.refreshToken('valid-uuid-token'))
+      .rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('lanza error 403 si la cuenta está suspendida', async () => {
+    userRepository.findById.mockResolvedValue({ ...USUARIO_DB, is_suspended: true });
+
+    await expect(authService.refreshToken('valid-uuid-token'))
+      .rejects.toMatchObject({ statusCode: 403 });
+  });
+});
+
+// changePassword
+
 describe('authService.changePassword', () => {
   const INPUT_VALIDO = { currentPassword: 'Password1', newPassword: 'NuevaPassword1' };
 
@@ -360,10 +458,11 @@ describe('authService.changePassword', () => {
     jest.clearAllMocks();
     userRepository.findById.mockResolvedValue(USUARIO_DB);
     bcrypt.compare
-      .mockResolvedValueOnce(true)  // primera llamada: contraseña actual correcta
-      .mockResolvedValueOnce(false); // segunda llamada: nueva contraseña ≠ anterior
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
     bcrypt.hash.mockResolvedValue('nuevo-hash');
     userRepository.updatePasswordAndInvalidateResetToken.mockResolvedValue();
+    userRepository.deleteAllRefreshTokensForUser.mockResolvedValue();
     userRepository.resetFailedAttempts.mockResolvedValue();
     sendPasswordChangedEmail.mockResolvedValue();
   });
@@ -371,10 +470,13 @@ describe('authService.changePassword', () => {
   it('actualiza la contraseña e invalida todas las sesiones activas', async () => {
     await authService.changePassword('user-uuid-1', INPUT_VALIDO);
 
-    expect(userRepository.updatePasswordAndInvalidateResetToken).toHaveBeenCalledWith(
-      'user-uuid-1',
-      'nuevo-hash'
-    );
+    expect(userRepository.updatePasswordAndInvalidateResetToken).toHaveBeenCalledWith('user-uuid-1', 'nuevo-hash');
+  });
+
+  it('elimina todos los refresh tokens del usuario al cambiar contraseña', async () => {
+    await authService.changePassword('user-uuid-1', INPUT_VALIDO);
+
+    expect(userRepository.deleteAllRefreshTokensForUser).toHaveBeenCalledWith('user-uuid-1');
   });
 
   it('resetea el contador de intentos fallidos al cambiar exitosamente', async () => {
@@ -416,7 +518,7 @@ describe('authService.changePassword', () => {
 
   it('lanza error 401 si la contraseña actual es incorrecta', async () => {
     bcrypt.compare.mockReset();
-    bcrypt.compare.mockResolvedValue(false); // contraseña incorrecta
+    bcrypt.compare.mockResolvedValue(false);
 
     await expect(authService.changePassword('user-uuid-1', INPUT_VALIDO)).rejects.toMatchObject({ statusCode: 401 });
   });
@@ -433,8 +535,8 @@ describe('authService.changePassword', () => {
   it('lanza error 400 si la nueva contraseña es igual a la actual', async () => {
     bcrypt.compare.mockReset();
     bcrypt.compare
-      .mockResolvedValueOnce(true)  // contraseña actual correcta
-      .mockResolvedValueOnce(true); // nueva contraseña == anterior
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
 
     await expect(authService.changePassword('user-uuid-1', INPUT_VALIDO)).rejects.toMatchObject({ statusCode: 400 });
     expect(userRepository.updatePasswordAndInvalidateResetToken).not.toHaveBeenCalled();

--- a/src/modules/auth/auth.controller.js
+++ b/src/modules/auth/auth.controller.js
@@ -1,13 +1,46 @@
 const { authService } = require('./auth.service');
+const { env } = require('../../config/env');
+
+const REFRESH_COOKIE_NAME = 'refreshToken';
+
+function getRefreshCookieOptions() {
+  const isProduction = env.APP_URL.startsWith('https');
+  return {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: isProduction ? 'None' : 'Lax',
+    path: '/api/auth',
+    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days in ms
+  };
+}
 
 const authController = {
   async login(req, res, next) {
     try {
-      const result = await authService.login(req.body);
+      const { accessToken, refreshToken, user } = await authService.login(req.body);
+
+      res.cookie(REFRESH_COOKIE_NAME, refreshToken, getRefreshCookieOptions());
+
       res.status(200).json({
         message: 'Inicio de sesión exitoso.',
-        ...result,
+        accessToken,
+        user,
       });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async refresh(req, res, next) {
+    try {
+      const token = req.cookies[REFRESH_COOKIE_NAME];
+      if (!token) {
+        return res.status(401).json({ error: 'Refresh token requerido' });
+      }
+
+      const { accessToken, newRefreshToken } = await authService.refreshToken(token);
+      res.cookie(REFRESH_COOKIE_NAME, newRefreshToken, getRefreshCookieOptions());
+      res.status(200).json({ accessToken });
     } catch (err) {
       next(err);
     }
@@ -33,7 +66,9 @@ const authController = {
 
   async logout(req, res, next) {
     try {
-      const result = await authService.logout(req.user.sub);
+      const refreshToken = req.cookies[REFRESH_COOKIE_NAME];
+      const result = await authService.logout(req.user.sub, refreshToken);
+      res.clearCookie(REFRESH_COOKIE_NAME, { path: '/api/auth' });
       res.status(200).json(result);
     } catch (err) {
       next(err);
@@ -54,6 +89,7 @@ const authController = {
     try {
       const userId = req.user.sub;
       const result = await authService.changePassword(userId, req.body);
+      res.clearCookie(REFRESH_COOKIE_NAME, { path: '/api/auth' });
       res.status(200).json(result);
     } catch (err) {
       next(err);

--- a/src/modules/auth/auth.routes.js
+++ b/src/modules/auth/auth.routes.js
@@ -18,6 +18,9 @@ router.post('/reset-password', validate(resetPasswordSchema), authController.res
 // GET /api/auth/reset-password?token=<uuid>
 router.get('/reset-password', authController.verifyResetToken);
 
+// POST /api/auth/refresh — get new access token using refresh token cookie
+router.post('/refresh', authController.refresh);
+
 // POST /api/auth/change-password
 router.post('/change-password', authenticate, validate(changePasswordSchema), authController.changePassword);
 // POST /api/auth/logout

--- a/src/modules/auth/auth.service.js
+++ b/src/modules/auth/auth.service.js
@@ -6,6 +6,8 @@ const { sendResetPasswordEmail, sendPasswordChangedEmail } = require('../../conf
 const { AppError } = require('../../middlewares/errorHandler');
 const { env } = require('../../config/env');
 
+const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
 const authService = {
   async login({ identifier, password }) {
     // CA.3: support email or username
@@ -28,8 +30,7 @@ const authService = {
 
     // CA.2: cuenta bloqueada por demasiados intentos fallidos
     if (user.locked_until && new Date(user.locked_until) > new Date()) {
-      //throw new AppError(423, `Cuenta bloqueada temporalmente. Intentá de nuevo en ${Math.ceil(((user.locked_until - new Date()) / 60000))} minutos.`); 
-      throw new AppError(423, `Cuenta bloqueada temporalmente. Intentá de nuevo en ${Math.ceil((user.locked_until - new Date()) / 60000)} minutos.`); 
+      throw new AppError(423, `Cuenta bloqueada temporalmente. Intentá de nuevo en ${Math.ceil((user.locked_until - new Date()) / 60000)} minutos.`);
     }
 
     // CA.4: email no verificado
@@ -47,15 +48,21 @@ const authService = {
     // Login exitoso: resetea el contador de intentos fallidos
     await userRepository.resetFailedAttempts(user.id);
 
-    // CA.1: genera JWT con expiración definida
-    const token = jwt.sign(
-      { sub: user.id, username: user.username, email: user.email, token_version: user.token_version },
+    // CA.1: access token JWT (corta duración)
+    const accessToken = jwt.sign(
+      { sub: user.id, username: user.username, email: user.email, token_version: user.token_version, type: 'access' },
       env.JWT_SECRET,
-      { expiresIn: env.JWT_EXPIRES_IN }
+      { expiresIn: env.ACCESS_TOKEN_EXPIRES_IN }
     );
 
+    // Refresh token opaco (UUID) guardado en BD
+    const refreshToken = uuidv4();
+    const refreshExpiresAt = new Date(Date.now() + REFRESH_TOKEN_TTL_MS);
+    await userRepository.createRefreshToken(user.id, refreshToken, refreshExpiresAt);
+
     return {
-      token,
+      accessToken,
+      refreshToken,
       user: {
         id: user.id,
         username: user.username,
@@ -82,9 +89,8 @@ const authService = {
 
     // CA.8: throttling - limit requests per account (e.g., 1 per minute)
     const THROTTLE_MINUTES = 1;
-    if (user.last_reset_request_at && 
+    if (user.last_reset_request_at &&
         new Date() - new Date(user.last_reset_request_at) < THROTTLE_MINUTES * 60 * 1000) {
-      // Even if throttled, return the generic message to avoid giving hints
       return { message: genericMessage };
     }
 
@@ -121,17 +127,49 @@ const authService = {
       throw new AppError(400, 'La nueva contraseña no puede ser igual a la anterior');
     }
 
-    // CA.3: enforce H1 policies (min 8 chars, 1 uppercase, 1 number)
-    // (Actual validation is also done via resetPasswordSchema, but we double-check here if needed)
-    
     // CA.5: hash new password, clear token, increment token_version (CA.7)
     const newPasswordHash = await bcrypt.hash(password, 12);
     await userRepository.updatePasswordAndInvalidateResetToken(user.id, newPasswordHash);
+    // CA.7: revocar todas las sesiones activas (H5)
+    await userRepository.deleteAllRefreshTokensForUser(user.id);
 
     return { message: 'Tu contraseña ha sido actualizada con éxito. Por favor, iniciá sesión de nuevo.' };
   },
 
-  async logout(userId) {
+  async refreshToken(currentRefreshToken) {
+    const newRefreshToken = uuidv4();
+    const refreshExpiresAt = new Date(Date.now() + REFRESH_TOKEN_TTL_MS);
+
+    // Rotación atómica en transacción: invalida el token viejo y crea el nuevo en un solo paso.
+    // Si dos requests usan el mismo token simultáneamente, solo uno obtiene el user_id.
+    const userId = await userRepository.rotateRefreshToken(currentRefreshToken, newRefreshToken, refreshExpiresAt);
+    if (!userId) {
+      throw new AppError(401, 'Refresh token inválido o expirado');
+    }
+
+    const user = await userRepository.findById(userId);
+    if (!user) {
+      throw new AppError(401, 'Sesión revocada. Por favor, iniciá sesión de nuevo.');
+    }
+
+    if (user.deleted_at || user.is_suspended) {
+      throw new AppError(403, 'Cuenta suspendida');
+    }
+
+    const accessToken = jwt.sign(
+      { sub: user.id, username: user.username, email: user.email, token_version: user.token_version, type: 'access' },
+      env.JWT_SECRET,
+      { expiresIn: env.ACCESS_TOKEN_EXPIRES_IN }
+    );
+
+    return { accessToken, newRefreshToken };
+  },
+
+  async logout(userId, refreshToken = null) {
+    if (refreshToken) {
+      await userRepository.deleteRefreshToken(refreshToken);
+    }
+    // Invalida el access token actual inmediatamente (H3 CA.1)
     await userRepository.incrementTokenVersion(userId);
     return { message: 'Sesión cerrada exitosamente.' };
   },
@@ -146,9 +184,9 @@ const authService = {
       throw new AppError(400, 'El token es inválido o ha expirado. Por favor, solicitá uno nuevo.');
     }
 
-    return { 
+    return {
       message: 'Token válido. Por favor, ingresá tu nueva contraseña.',
-      token 
+      token,
     };
   },
 
@@ -176,10 +214,10 @@ const authService = {
       throw new AppError(400, 'La nueva contraseña no puede ser igual a la anterior');
     }
 
-    // Success: update password, invalidate sessions (token_version++), reset attempts
+    // Success: update password (token_version++), reset attempts, revocar todas las sesiones
     const newPasswordHash = await bcrypt.hash(newPassword, 12);
-    
     await userRepository.updatePasswordAndInvalidateResetToken(user.id, newPasswordHash);
+    await userRepository.deleteAllRefreshTokensForUser(user.id);
     await userRepository.resetFailedAttempts(user.id);
 
     // CA.5: Send email notification

--- a/src/modules/internal/internal.routes.js
+++ b/src/modules/internal/internal.routes.js
@@ -1,0 +1,41 @@
+const { Router } = require('express');
+const jwt = require('jsonwebtoken');
+const { env } = require('../../config/env');
+const { userRepository } = require('../users/user.repository');
+const { authenticateInternal } = require('../../middlewares/authenticateInternal');
+
+const router = Router();
+
+// GET /api/internal/validate-token
+// Llamado por el gateway para verificar que el JWT no fue revocado (token_version)
+// Requiere: Authorization: Bearer <jwt>  +  x-internal-secret: <secret>
+router.get('/validate-token', authenticateInternal, async (req, res, next) => {
+  try {
+    const authHeader = req.headers['authorization'];
+    const token = authHeader && authHeader.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : null;
+
+    if (!token) {
+      return res.status(401).json({ error: 'Token requerido' });
+    }
+
+    let payload;
+    try {
+      payload = jwt.verify(token, env.JWT_SECRET);
+    } catch {
+      return res.status(401).json({ error: 'Token inválido o expirado' });
+    }
+
+    const user = await userRepository.findById(payload.sub);
+    if (!user || user.token_version !== payload.token_version) {
+      return res.status(401).json({ error: 'Sesión revocada' });
+    }
+
+    res.json({ valid: true, userId: payload.sub });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/src/modules/users/user.repository.js
+++ b/src/modules/users/user.repository.js
@@ -1,4 +1,5 @@
-const { query } = require('../../config/database');
+const { query, withTransaction } = require('../../config/database');
+const { hashToken } = require('../../utils/tokenHash');
 
 const userRepository = {
   // CA.7: lookup uses LOWER() for case-insensitive comparison
@@ -194,6 +195,48 @@ const userRepository = {
       [userId, biography]
     );
     return result.rows[0] ?? null;
+  },
+
+  async createRefreshToken(userId, token, expiresAt) {
+    await query(
+      `INSERT INTO user_refresh_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)`,
+      [userId, hashToken(token), expiresAt]
+    );
+  },
+
+  // Rotación atómica en transacción:
+  // 1. DELETE del token viejo (RETURNING user_id) — si dos requests usan el mismo token
+  //    simultáneamente, solo uno obtiene la fila; el otro ve 0 rows y recibe null.
+  // 2. INSERT del token nuevo dentro de la misma transacción.
+  // Devuelve el user_id si el token era válido, o null si no existía/expiró.
+  async rotateRefreshToken(oldToken, newToken, expiresAt) {
+    const oldHash = hashToken(oldToken);
+    const newHash = hashToken(newToken);
+
+    return withTransaction(async (client) => {
+      const { rows } = await client.query(
+        `DELETE FROM user_refresh_tokens WHERE token_hash = $1 AND expires_at > NOW() RETURNING user_id`,
+        [oldHash]
+      );
+
+      if (rows.length === 0) return null;
+
+      const { user_id } = rows[0];
+      await client.query(
+        `INSERT INTO user_refresh_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)`,
+        [user_id, newHash, expiresAt]
+      );
+
+      return user_id;
+    });
+  },
+
+  async deleteRefreshToken(token) {
+    await query(`DELETE FROM user_refresh_tokens WHERE token_hash = $1`, [hashToken(token)]);
+  },
+
+  async deleteAllRefreshTokensForUser(userId) {
+    await query(`DELETE FROM user_refresh_tokens WHERE user_id = $1`, [userId]);
   },
 
   // H6: obtiene el perfil público del usuario (username + biography)

--- a/src/modules/users/user.schemas.js
+++ b/src/modules/users/user.schemas.js
@@ -1,5 +1,9 @@
 const { z } = require('zod');
 
+const SEARCH_RADIUS_MIN = 1;
+const SEARCH_RADIUS_MAX = 50;
+const ALLOWED_UPDATE_FREQUENCIES = [5, 15, 30];
+
 // CA.2: valid email format
 // CA.3: username 4-15 chars, alphanumeric only, unique (uniqueness checked in service)
 // CA.4: password min 8 chars, 1 uppercase, 1 number
@@ -23,7 +27,6 @@ const registerSchema = z.object({
 
   acceptedTerms: z
     .boolean({ required_error: 'Leer y aceptar los Términos y Condiciones y la Política de Privacidad es obligatorio' }),
-
 });
 
 const resendVerificationSchema = z.object({
@@ -39,21 +42,21 @@ const deleteSchema = z.object({
     .min(1, 'La contraseña es obligatoria'),
 });
 
+// CA.1: radio 1-50 km, CA.4: frecuencia solo 5, 15 o 30
 const updatePreferencesSchema = z.object({
   search_radius_km: z
     .number({ invalid_type_error: 'El radio debe ser un número' })
-    .min(1, 'El radio de búsqueda no puede ser menor a 1 km')
-    .max(50, 'El radio de búsqueda no puede superar los 50 km')
+    .min(SEARCH_RADIUS_MIN, `El radio de búsqueda no puede ser menor a ${SEARCH_RADIUS_MIN} km`)
+    .max(SEARCH_RADIUS_MAX, `El radio de búsqueda no puede superar los ${SEARCH_RADIUS_MAX} km`)
     .optional(),
   location_update_frequency: z
     .number({ invalid_type_error: 'La frecuencia debe ser un número' })
-    .refine((val) => [5, 15, 30].includes(val), {
-      message: 'La frecuencia de actualización solo puede ser 5, 15 o 30 minutos',
+    .refine((val) => ALLOWED_UPDATE_FREQUENCIES.includes(val), {
+      message: `La frecuencia de actualización solo puede ser ${ALLOWED_UPDATE_FREQUENCIES.join(', ')} minutos`,
     })
     .optional(),
 });
 
-module.exports = { registerSchema, resendVerificationSchema, deleteSchema, updatePreferencesSchema };
 // H6: editar perfil — al menos un campo obligatorio, email no editable (CA.2)
 const updateProfileSchema = z
   .object({
@@ -75,4 +78,10 @@ const updateProfileSchema = z
     { message: 'Debés enviar al menos un campo para actualizar (username o biography)' }
   );
 
-module.exports = { registerSchema, resendVerificationSchema, deleteSchema, updateProfileSchema };
+module.exports = {
+  registerSchema,
+  resendVerificationSchema,
+  deleteSchema,
+  updatePreferencesSchema,
+  updateProfileSchema,
+};

--- a/src/utils/tokenHash.js
+++ b/src/utils/tokenHash.js
@@ -1,0 +1,7 @@
+const crypto = require('crypto');
+
+function hashToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+module.exports = { hashToken };


### PR DESCRIPTION
 Implementación Access Token + Refresh Token

Antes: un único JWT de 7 días devuelto en el body del login. Si se filtraba, el atacante tenía acceso durante 7 días sin forma de revocarlo por sesión.

Ahora: AT (15m) y RT (7d).

El AT es muy parecido al JWT inicial, mas corto
El RT es un UUID que se guarda en la base de datos (se guarda el hash en realidad siguiendo OWASP)

Principales ccambios

1. Login
Antes: POST /api/auth/login  devolvía { token, user } en el body.
Ahora : El service genera el AT (JWT) y el RT (UUID), guarda el hash del RT en la BD
, el controller setea la cookie con el RT
y el body devuelve solo { accessToken, user }

2. Logout
Antes: solo incrementaba token_version (revocaba el AT de todos los dispositivos).

Ahora:
 Lee el RT de la cookie
, deleteRefreshToken revoca esta sesión específica
, incrementTokenVersion invalida el AT activo inmediatamente
 y clearCookie borra la cookie del cliente

3.  POST /api/auth/refresh lee RT de la cookie, ejecuta la rotación atómica, devuelve el AT y setea nueva cookie con el RT rotado.