### PR TITLE
Debt tech superadmin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ INITIAL_SUPERADMIN_TEMP_PASSWORD=<temp_password>
 APP_URL=http://localhost:3000
 
 JWT_SECRET=una_clave_secreta_muy_larga_y_segura_cambiar_en_produccion
+ADMIN_JWT_SECRET=otra_clave_secreta_distinta_solo_para_admins
 JWT_EXPIRES_IN=7d
 ACCESS_TOKEN_EXPIRES_IN=15m
 REFRESH_TOKEN_EXPIRES_IN=7d

--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,10 @@ PORT=3000
 DB_HOST=db
 DB_PORT=5432
 DB_NAME=users_db
-DB_USER=admin
-DB_PASSWORD=secret
+DB_USER=api_user
+DB_PASSWORD=api_password
+DB_ADMIN_USER=admin
+DB_ADMIN_PASSWORD=secret
 
 SMTP_HOST=smtp.mailtrap.io
 SMTP_PORT=587

--- a/package-lock.json
+++ b/package-lock.json
@@ -4204,9 +4204,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
-      "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/src/clients/friendsClient.js
+++ b/src/clients/friendsClient.js
@@ -1,0 +1,19 @@
+// H4 CA.2/CA.4: cliente HTTP para notificar al servicio de friends que elimine
+// todas las relaciones (aceptadas y pendientes) de un usuario eliminado.
+
+const friendsClient = {
+  /**
+   * Elimina lógicamente todas las relaciones de amistad del usuario dado.
+   * @param {string} userId
+   */
+  async deleteUserRelationships(userId) {
+    const url = `${process.env.FRIENDS_SERVICE_URL}/api/friends/user/${userId}`;
+    const response = await fetch(url, { method: 'DELETE' });
+
+    if (!response.ok) {
+      throw new Error(`Friends service error: ${response.status}`);
+    }
+  },
+};
+
+module.exports = { friendsClient };

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -1,6 +1,16 @@
 const { Pool } = require('pg');
 const { env } = require('./env');
 
+// Pool privilegiado para migraciones (CREATE TABLE, GRANT, etc.)
+const migrationPool = new Pool({
+  host: env.DB_HOST,
+  port: parseInt(env.DB_PORT, 10),
+  database: env.DB_NAME,
+  user: env.DB_ADMIN_USER || env.DB_USER,
+  password: env.DB_ADMIN_PASSWORD || env.DB_PASSWORD,
+});
+
+// Pool de la app con privilegios limitados (SELECT, INSERT, UPDATE, DELETE)
 const pool = new Pool({
   host: env.DB_HOST,
   port: parseInt(env.DB_PORT, 10),
@@ -29,4 +39,4 @@ async function withTransaction(fn) {
   }
 }
 
-module.exports = { pool, query, withTransaction };
+module.exports = { pool, migrationPool, query, withTransaction };

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -18,6 +18,7 @@ const envSchema = z.object({
   APP_URL: z.string().url(),
 
   JWT_SECRET: z.string(),
+  ADMIN_JWT_SECRET: z.string(),
   JWT_EXPIRES_IN: z.string().default('7d'),
   ACCESS_TOKEN_EXPIRES_IN: z.string().default('15m'),
   REFRESH_TOKEN_EXPIRES_IN: z.string().default('7d'),

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -26,6 +26,9 @@ const envSchema = z.object({
 
   INITIAL_SUPERADMIN_EMAIL: z.string().email().optional(),
   INITIAL_SUPERADMIN_TEMP_PASSWORD: z.string().optional(),
+
+  // URL del servicio de friends (H4 CA.2/CA.4: eliminar relaciones al borrar cuenta)
+  FRIENDS_SERVICE_URL: z.string().url().optional(),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -8,6 +8,8 @@ const envSchema = z.object({
   DB_NAME: z.string(),
   DB_USER: z.string(),
   DB_PASSWORD: z.string(),
+  DB_ADMIN_USER: z.string().optional(),
+  DB_ADMIN_PASSWORD: z.string().optional(),
 
   SMTP_HOST: z.string().optional(),
   SMTP_PORT: z.string().default('587'),

--- a/src/db/migrations/003_create_refresh_tokens.sql
+++ b/src/db/migrations/003_create_refresh_tokens.sql
@@ -1,4 +1,4 @@
-CREATE TABLE user_refresh_tokens (
+CREATE TABLE IF NOT EXISTS user_refresh_tokens (
   id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id    UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   token_hash VARCHAR(64)  NOT NULL UNIQUE, -- SHA-256 hex del token opaco
@@ -6,9 +6,9 @@ CREATE TABLE user_refresh_tokens (
   created_at TIMESTAMPTZ  DEFAULT NOW()
 );
 
-CREATE INDEX user_refresh_tokens_user_id_idx ON user_refresh_tokens(user_id);
+CREATE INDEX IF NOT EXISTS user_refresh_tokens_user_id_idx ON user_refresh_tokens(user_id);
 
-CREATE TABLE admin_refresh_tokens (
+CREATE TABLE IF NOT EXISTS admin_refresh_tokens (
   id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   admin_id   UUID         NOT NULL REFERENCES admins(id) ON DELETE CASCADE,
   token_hash VARCHAR(64)  NOT NULL UNIQUE, -- SHA-256 hex del token opaco
@@ -16,4 +16,4 @@ CREATE TABLE admin_refresh_tokens (
   created_at TIMESTAMPTZ  DEFAULT NOW()
 );
 
-CREATE INDEX admin_refresh_tokens_admin_id_idx ON admin_refresh_tokens(admin_id);
+CREATE INDEX IF NOT EXISTS admin_refresh_tokens_admin_id_idx ON admin_refresh_tokens(admin_id);

--- a/src/db/migrations/004_seed_superadmin.js
+++ b/src/db/migrations/004_seed_superadmin.js
@@ -1,0 +1,21 @@
+const bcrypt = require('bcryptjs');
+const { env } = require('../../config/env');
+
+module.exports = async function seedSuperAdmin(pool) {
+  if (!env.INITIAL_SUPERADMIN_EMAIL || !env.INITIAL_SUPERADMIN_TEMP_PASSWORD) return;
+
+  const { rows } = await pool.query('SELECT COUNT(*) FROM admins');
+  if (parseInt(rows[0].count, 10) > 0) return;
+
+  const passwordHash = await bcrypt.hash(env.INITIAL_SUPERADMIN_TEMP_PASSWORD, 12);
+  const expiresAt = new Date();
+  expiresAt.setHours(expiresAt.getHours() + 24);
+
+  await pool.query(
+    `INSERT INTO admins (email, password_hash, role, must_change_password, temp_password_expires_at)
+     VALUES (LOWER($1), $2, 'superadmin', TRUE, $3)`,
+    [env.INITIAL_SUPERADMIN_EMAIL, passwordHash, expiresAt]
+  );
+
+  console.log(`SuperAdmin inicial creado: ${env.INITIAL_SUPERADMIN_EMAIL}`);
+};

--- a/src/db/migrations/005_create_api_user.js
+++ b/src/db/migrations/005_create_api_user.js
@@ -1,0 +1,26 @@
+const { env } = require('../../config/env');
+
+module.exports = async function createApiUser(pool) {
+  // Si DB_ADMIN_USER no está definido, la app ya corre como el único usuario 
+  // esto es para q sea compatible con lo anterior pero quizas lo podemos borrar despues
+  if (!env.DB_ADMIN_USER) return;
+
+  const apiUser = env.DB_USER;
+  const apiPassword = env.DB_PASSWORD;
+
+  const { rows } = await pool.query(
+    `SELECT 1 FROM pg_roles WHERE rolname = $1`,
+    [apiUser]
+  );
+
+  if (rows.length === 0) {
+    await pool.query(`CREATE USER "${apiUser}" WITH PASSWORD '${apiPassword}'`);
+    console.log(`Usuario de base de datos creado: ${apiUser}`);
+  }
+
+  // Poner permisos al usuario
+  await pool.query(`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO "${apiUser}"`);
+  await pool.query(`ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "${apiUser}"`); // por si en el uturo se crean mas migraciones
+  await pool.query(`GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO "${apiUser}"`);
+  await pool.query(`ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SEQUENCES TO "${apiUser}"`);
+};

--- a/src/middlewares/authenticateAdmin.js
+++ b/src/middlewares/authenticateAdmin.js
@@ -14,7 +14,7 @@ async function authenticateAdmin(req, _res, next) {
   }
 
   try {
-    const payload = jwt.verify(token, env.JWT_SECRET);
+    const payload = jwt.verify(token, env.ADMIN_JWT_SECRET);
 
     // Verifica que sea un token de admin (debe tener campo role)
     if (!payload.role) {

--- a/src/modules/admin-auth/__tests__/admin-auth.service.test.js
+++ b/src/modules/admin-auth/__tests__/admin-auth.service.test.js
@@ -25,7 +25,7 @@ jest.mock('../../../config/mailer', () => ({
 }));
 
 jest.mock('../../../config/env', () => ({
-  env: { JWT_SECRET: 'test-secret', ACCESS_TOKEN_EXPIRES_IN: '15m', REFRESH_TOKEN_EXPIRES_IN: '7d' },
+  env: { JWT_SECRET: 'test-secret', ADMIN_JWT_SECRET: 'test-admin-secret', ACCESS_TOKEN_EXPIRES_IN: '15m', REFRESH_TOKEN_EXPIRES_IN: '7d' },
 }));
 
 jest.mock('bcryptjs');
@@ -82,7 +82,7 @@ describe('adminAuthService.login', () => {
 
     expect(jwt.sign).toHaveBeenCalledWith(
       expect.objectContaining({ role: 'superadmin', must_change_password: false, type: 'access' }),
-      'test-secret',
+      'test-admin-secret',
       { expiresIn: '15m' }
     );
     expect(jwt.sign).toHaveBeenCalledTimes(1);
@@ -215,7 +215,7 @@ describe('adminAuthService.refreshToken', () => {
 
     expect(jwt.sign).toHaveBeenCalledWith(
       expect.objectContaining({ sub: 'admin-uuid-1', role: 'superadmin', type: 'access' }),
-      'test-secret',
+      'test-admin-secret',
       { expiresIn: '15m' }
     );
   });

--- a/src/modules/admin-auth/admin-auth.controller.js
+++ b/src/modules/admin-auth/admin-auth.controller.js
@@ -7,7 +7,7 @@ function getRefreshCookieOptions() {
   const isProduction = env.APP_URL.startsWith('https');
   return {
     httpOnly: true,
-    secure: isProduction,
+    secure: true,
     sameSite: isProduction ? 'None' : 'Lax',
     path: '/api/admin/auth',
     maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days in ms

--- a/src/modules/admin-auth/admin-auth.service.js
+++ b/src/modules/admin-auth/admin-auth.service.js
@@ -40,7 +40,7 @@ const adminAuthService = {
 
     await adminRepository.resetFailedAttempts(admin.id);
 
-    // H2 CA.1: access token JWT (corta duración)
+    // H2 CA.1: access token JWT (corta duración) — secret separado de users
     const accessToken = jwt.sign(
       {
         sub: admin.id,
@@ -50,7 +50,7 @@ const adminAuthService = {
         must_change_password: admin.must_change_password,
         type: 'access',
       },
-      env.JWT_SECRET,
+      env.ADMIN_JWT_SECRET,
       { expiresIn: env.ACCESS_TOKEN_EXPIRES_IN }
     );
 
@@ -95,7 +95,7 @@ const adminAuthService = {
         must_change_password: admin.must_change_password,
         type: 'access',
       },
-      env.JWT_SECRET,
+      env.ADMIN_JWT_SECRET,
       { expiresIn: env.ACCESS_TOKEN_EXPIRES_IN }
     );
 

--- a/src/modules/auth/auth.controller.js
+++ b/src/modules/auth/auth.controller.js
@@ -7,7 +7,7 @@ function getRefreshCookieOptions() {
   const isProduction = env.APP_URL.startsWith('https');
   return {
     httpOnly: true,
-    secure: isProduction,
+    secure: true,
     sameSite: isProduction ? 'None' : 'Lax',
     path: '/api/auth',
     maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days in ms

--- a/src/modules/users/__tests__/user.service.test.js
+++ b/src/modules/users/__tests__/user.service.test.js
@@ -4,6 +4,7 @@ const { userService } = require('../user.service');
 const { userRepository } = require('../user.repository');
 const { sendVerificationEmail } = require('../../../config/mailer');
 const { AppError } = require('../../../middlewares/errorHandler');
+const { friendsClient } = require('../../../clients/friendsClient');
 
 // Reemplazamos los módulos reales por versiones falsas que controlamos.
 // Usamos factory functions (el () => ...) para que Jest nunca llegue a
@@ -30,6 +31,12 @@ jest.mock('../user.repository', () => ({
 
 jest.mock('../../../config/mailer', () => ({
   sendVerificationEmail: jest.fn(),
+}));
+
+jest.mock('../../../clients/friendsClient', () => ({
+  friendsClient: {
+    deleteUserRelationships: jest.fn(),
+  },
 }));
 
 jest.mock('bcryptjs');
@@ -284,6 +291,54 @@ describe('userService.delete', () => {
 
     await expect(userService.delete('user-uuid-1', 'wrong')).rejects.toMatchObject({ statusCode: 401 });
     expect(userRepository.markDeleted).not.toHaveBeenCalled();
+  });
+
+  describe('llamada al servicio friends (CA.2/CA.4)', () => {
+    beforeEach(() => {
+      process.env.FRIENDS_SERVICE_URL = 'http://friends-service';
+      friendsClient.deleteUserRelationships.mockResolvedValue();
+    });
+
+    afterEach(() => {
+      delete process.env.FRIENDS_SERVICE_URL;
+    });
+
+    it('llama a deleteUserRelationships con el userId del usuario eliminado', async () => {
+      await userService.delete('user-uuid-1', 'Password1');
+
+      expect(friendsClient.deleteUserRelationships).toHaveBeenCalledWith('user-uuid-1');
+    });
+
+    it('ejecuta el soft-delete antes de notificar a friends', async () => {
+      const orden = [];
+      userRepository.markDeleted.mockImplementation(() => { orden.push('markDeleted'); return Promise.resolve(); });
+      friendsClient.deleteUserRelationships.mockImplementation(() => { orden.push('deleteRelationships'); return Promise.resolve(); });
+
+      await userService.delete('user-uuid-1', 'Password1');
+
+      expect(orden).toEqual(['markDeleted', 'deleteRelationships']);
+    });
+
+    it('no llama a friendsClient si FRIENDS_SERVICE_URL no está configurado', async () => {
+      delete process.env.FRIENDS_SERVICE_URL;
+
+      await userService.delete('user-uuid-1', 'Password1');
+
+      expect(friendsClient.deleteUserRelationships).not.toHaveBeenCalled();
+    });
+
+    it('propaga el error si el servicio friends no está disponible', async () => {
+      friendsClient.deleteUserRelationships.mockRejectedValue(new Error('Friends service error: 503'));
+
+      await expect(userService.delete('user-uuid-1', 'Password1')).rejects.toThrow('Friends service error: 503');
+    });
+
+    it('no llama a friendsClient si la contraseña es incorrecta', async () => {
+      bcrypt.compare.mockResolvedValue(false);
+
+      await expect(userService.delete('user-uuid-1', 'wrong')).rejects.toThrow();
+      expect(friendsClient.deleteUserRelationships).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/modules/users/user.service.js
+++ b/src/modules/users/user.service.js
@@ -3,6 +3,7 @@ const { v4: uuidv4 } = require('uuid');
 const { userRepository } = require('./user.repository');
 const { sendVerificationEmail } = require('../../config/mailer');
 const { AppError } = require('../../middlewares/errorHandler');
+const { friendsClient } = require('../../clients/friendsClient');
 
 const TOKEN_EXPIRY_HOURS = 24;
 
@@ -107,6 +108,11 @@ const userService = {
 
     // CA.1: soft-delete — no borra la fila, solo marca deleted_at
     await userRepository.markDeleted(userId);
+
+    // CA.2/CA.4: eliminar todas las relaciones de amistad en el servicio friends
+    if (process.env.FRIENDS_SERVICE_URL) {
+      await friendsClient.deleteUserRelationships(userId);
+    }
   },
 
   async getPreferences(userId) {

--- a/src/server.js
+++ b/src/server.js
@@ -2,44 +2,34 @@ require('dotenv').config();
 
 const fs = require('fs');
 const path = require('path');
-const bcrypt = require('bcryptjs');
 const { env } = require('./config/env');
-const { pool } = require('./config/database');
+const { migrationPool } = require('./config/database');
 const app = require('./app');
 
 async function runMigrations() {
   const migrationsDir = path.join(__dirname, 'db', 'migrations');
-  const files = fs.readdirSync(migrationsDir).filter(f => f.endsWith('.sql')).sort();
+  const files = fs.readdirSync(migrationsDir)
+    .filter(f => f.endsWith('.sql') || f.endsWith('.js'))
+    .sort();
 
   for (const file of files) {
-    const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf-8');
-    await pool.query(sql);
+    const filePath = path.join(migrationsDir, file);
+
+    if (file.endsWith('.sql')) {
+      const sql = fs.readFileSync(filePath, 'utf-8');
+      await migrationPool.query(sql);
+    } else {
+      const migration = require(filePath);
+      await migration(migrationPool);
+    }
+
     console.log(`Migration applied: ${file}`);
   }
 }
 
-async function seedInitialSuperAdmin() {
-  if (!env.INITIAL_SUPERADMIN_EMAIL || !env.INITIAL_SUPERADMIN_TEMP_PASSWORD) return;
-
-  const { rows } = await pool.query('SELECT COUNT(*) FROM admins');
-  if (parseInt(rows[0].count, 10) > 0) return;
-
-  const passwordHash = await bcrypt.hash(env.INITIAL_SUPERADMIN_TEMP_PASSWORD, 12);
-  const expiresAt = new Date();
-  expiresAt.setHours(expiresAt.getHours() + 24);
-
-  await pool.query(
-    `INSERT INTO admins (email, password_hash, role, must_change_password, temp_password_expires_at)
-     VALUES (LOWER($1), $2, 'superadmin', TRUE, $3)`,
-    [env.INITIAL_SUPERADMIN_EMAIL, passwordHash, expiresAt]
-  );
-
-  console.log(`SuperAdmin inicial creado: ${env.INITIAL_SUPERADMIN_EMAIL}`);
-}
-
 async function start() {
   await runMigrations();
-  await seedInitialSuperAdmin();
+  await migrationPool.end();
 
   const port = parseInt(env.PORT, 10);
   app.listen(port, () => {


### PR DESCRIPTION
Se reorganizó el arranque del microservicio de users. El seed del superadmin inicial, que antes vivía como función imperativa en server.js y se ejecutaba en cada arranque, se movió a una migración JS (004_seed_superadmin.js) dentro del pipeline de migraciones, manteniendo la misma lógica idempotente.  Por otro lado, se implementó el principio de mínimo privilegio en la conexión a PostgreSQL: se separó la conexión en dos pools: uno privilegiado (migrationPool, conectado como postgres) que se usa exclusivamente para correr las migraciones y se cierra inmediatamente después, y uno limitado (pool, conectado como api_user) que es el que usa la app en runtime. Una nueva migración (005_create_api_user.js) crea este usuario con permisos restringidos a SELECT, INSERT, UPDATE y DELETE, sin capacidad de modificar la estructura de la base de datos. De esta forma, si la API fuera comprometida, el atacante no podría ejecutar operaciones destructivas como DROP TABLE, ALTER TABLE o CREATE USER.

Estas son 2 de las correcciones de Alejo:
"El super admin es conveniente ponerlo como  parte de la migracion (No es necesario cambiarlo a esta altura, solo para que tengan en cuenta)
La api esta utilizando las credenciales del superadmin, esto no deberia ser asi. Pueden dejarlo por el momento pero es buena practica que la api tenga un user en la db con menos privilegios"