### PR TITLE
Que no se muestre a si mismo. Que no se muestren las cuentas eliminadas

### DIFF
--- a/src/modules/users/user.controller.js
+++ b/src/modules/users/user.controller.js
@@ -54,6 +54,16 @@ const userController = {
       next(err);
     }
   },
+
+  async searchUsers(req, res, next) {
+    try {
+      const { username } = req.query;
+      const users = await userService.searchUsersPublic(username, req.user.sub);
+      res.status(200).json(users);
+    } catch (err) {
+      next(err);
+    }
+  },
 };
 
 module.exports = { userController };

--- a/src/modules/users/user.repository.js
+++ b/src/modules/users/user.repository.js
@@ -251,22 +251,46 @@ const userRepository = {
   },
 
   // H4: búsqueda de usuarios con soporte de coincidencias parciales y paginación
-  async searchUsers({ search = '', page = 1, limit = 20 }) {
+  async searchUsers({ search = '', page = 1, limit = 20, excludeId = null, onlyActive = false }) {
     const offset = (page - 1) * limit;
     const pattern = `%${search}%`;
+    
+    let whereClause = '(u.username ILIKE $1 OR u.email ILIKE $1)';
+    const params = [pattern, limit, offset];
+    
+    if (excludeId) {
+      params.push(excludeId);
+      whereClause += ` AND u.id != $${params.length}`;
+    }
+
+    if (onlyActive) {
+      whereClause += ' AND u.deleted_at IS NULL';
+    }
+
     const result = await query(
       `SELECT u.id, u.username, u.email, u.is_verified, u.is_suspended,
               u.deleted_at, u.created_at, u.last_login_at,
               u.failed_login_attempts, u.locked_until
        FROM users u
-       WHERE (u.username ILIKE $1 OR u.email ILIKE $1)
+       WHERE ${whereClause}
        ORDER BY u.created_at DESC
        LIMIT $2 OFFSET $3`,
-      [pattern, limit, offset]
+      params
     );
+
+    const countParams = [pattern];
+    let countWhere = '(username ILIKE $1 OR email ILIKE $1)';
+    if (excludeId) {
+      countParams.push(excludeId);
+      countWhere += ` AND id != $${countParams.length}`;
+    }
+    if (onlyActive) {
+      countWhere += ' AND deleted_at IS NULL';
+    }
+
     const countResult = await query(
-      `SELECT COUNT(*) FROM users WHERE username ILIKE $1 OR email ILIKE $1`,
-      [pattern]
+      `SELECT COUNT(*) FROM users WHERE ${countWhere}`,
+      countParams
     );
     return {
       users: result.rows,

--- a/src/modules/users/user.routes.js
+++ b/src/modules/users/user.routes.js
@@ -23,4 +23,6 @@ router.patch(
 
 router.patch('/profile', authenticate, validate(updateProfileSchema), userController.updateProfile);
 
+router.get('/search', authenticate, userController.searchUsers);
+
 module.exports = router;

--- a/src/modules/users/user.service.js
+++ b/src/modules/users/user.service.js
@@ -179,6 +179,21 @@ const userService = {
     return updates; // CA.6: retorna los nuevos valores para actualizar el estado global
   },
 
+  async searchUsersPublic(query, excludeId) {
+    if (!query) return [];
+    // We can reuse the repository's search but we map it to return only public data
+    const result = await userRepository.searchUsers({ 
+      search: query, 
+      page: 1, 
+      limit: 10,
+      excludeId,
+      onlyActive: true
+    });
+    return result.users.map(u => ({
+      id: u.id,
+      username: u.username
+    }));
+  },
 };
 
 module.exports = { userService };

--- a/tests/unit/user.service.test.js
+++ b/tests/unit/user.service.test.js
@@ -26,6 +26,7 @@ jest.mock('../../src/modules/users/user.repository', () => ({
     getPreferences: jest.fn(),
     updateUsername: jest.fn(),
     updateBiography: jest.fn(),
+    searchUsers: jest.fn(),
   },
 }));
 
@@ -532,5 +533,47 @@ describe('userService.updateProfile', () => {
     await userService.updateProfile(USER_ID, { biography: '<b></b>' });
 
     expect(userRepository.updateBiography).toHaveBeenCalledWith(USER_ID, '');
+  });
+});
+
+describe('userService.searchUsersPublic', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('devuelve un array vacío si la query está vacía', async () => {
+    const result = await userService.searchUsersPublic('', 'user-uuid-1');
+    expect(result).toEqual([]);
+    expect(userRepository.searchUsers).not.toHaveBeenCalled();
+  });
+
+  it('llama al repositorio con excludeId y onlyActive: true', async () => {
+    userRepository.searchUsers.mockResolvedValue({ users: [] });
+    
+    await userService.searchUsersPublic('test', 'user-uuid-1');
+    
+    expect(userRepository.searchUsers).toHaveBeenCalledWith({
+      search: 'test',
+      page: 1,
+      limit: 10,
+      excludeId: 'user-uuid-1',
+      onlyActive: true,
+    });
+  });
+
+  it('mapea correctamente retornando solo campos públicos', async () => {
+    userRepository.searchUsers.mockResolvedValue({
+      users: [
+        { id: 'uuid-1', username: 'mateo', email: 'hola@test.com', locked_until: 'algo' },
+        { id: 'uuid-2', username: 'juan', email: 'juan@test.com' },
+      ],
+    });
+
+    const result = await userService.searchUsersPublic('ma', 'user-uuid-99');
+    
+    expect(result).toEqual([
+      { id: 'uuid-1', username: 'mateo' },
+      { id: 'uuid-2', username: 'juan' },
+    ]);
   });
 });


### PR DESCRIPTION
Cambios que sirven para que consuma el frontend.
Ahora hay una ruta que al recibir un nombre de usuario lo traduce a uuid del usuario. Y esto luego se usa en friends para hacer la busqueda de usuarios.