### PR TITLE
Fix deeplink

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -10,7 +10,6 @@ data:
   ACCESS_TOKEN_EXPIRES_IN: "15m"
   REFRESH_TOKEN_EXPIRES_IN: "7d"
   APP_URL: "https://tds-group-3.tds-linar.udesa.edu.ar"
-  MOBILE_RESET_PASSWORD_URL: "exp://tds-group-3.tds-linar.udesa.edu.ar/--/reset-password"
   ALLOWED_EMAIL_DOMAIN: "udesa.edu.ar"
   SMTP_PORT: "587"
   SMTP_FROM: "noreply@udesa.edu.ar"

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -10,7 +10,7 @@ data:
   ACCESS_TOKEN_EXPIRES_IN: "15m"
   REFRESH_TOKEN_EXPIRES_IN: "7d"
   APP_URL: "https://tds-group-3.tds-linar.udesa.edu.ar"
-  MOBILE_RESET_PASSWORD_URL: "exp://tds-group-3.tds-linar.udesa.edu.ar/--/ResetPassword"
+  MOBILE_RESET_PASSWORD_URL: "exp://tds-group-3.tds-linar.udesa.edu.ar/--/reset-password"
   ALLOWED_EMAIL_DOMAIN: "udesa.edu.ar"
   SMTP_PORT: "587"
   SMTP_FROM: "noreply@udesa.edu.ar"

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -27,8 +27,6 @@ const envSchema = z.object({
   INITIAL_SUPERADMIN_EMAIL: z.string().email().optional(),
   INITIAL_SUPERADMIN_TEMP_PASSWORD: z.string().optional(),
   
-  MOBILE_DEEP_LINK_URL: z.string().optional(),
-  MOBILE_RESET_PASSWORD_URL: z.string().optional(),
 
   // URL del servicio de friends (H4 CA.2/CA.4: eliminar relaciones al borrar cuenta)
   FRIENDS_SERVICE_URL: z.string().url().optional(),

--- a/src/config/mailer.js
+++ b/src/config/mailer.js
@@ -54,8 +54,11 @@ async function sendVerificationEmail(toEmail, token) {
   }
 }
 
-async function sendResetPasswordEmail(toEmail, token) {
-  const resetUrl = `${env.APP_URL}/api/auth/reset-password?token=${token}`;
+async function sendResetPasswordEmail(toEmail, token, returnUrl) {
+  let resetUrl = `${env.APP_URL}/api/auth/reset-password?token=${token}`;
+  if (returnUrl) {
+    resetUrl += `&returnUrl=${encodeURIComponent(returnUrl)}`;
+  }
 
   if (!transporter) {
     console.log('─────────────────────────────────────────────');

--- a/src/modules/auth/auth.controller.js
+++ b/src/modules/auth/auth.controller.js
@@ -67,8 +67,6 @@ const authController = {
       const returnUrl = req.query['returnUrl'];
       await authService.verifyResetToken(token); // Valida internamente
 
-      const { env } = require('../../config/env');
-
       const deepLinkBase = returnUrl || 'udesamigos://reset-password';
       // Si el link base ya contiene el esquema y el path, solo agregamos el token
       const deepLink = `${deepLinkBase}${deepLinkBase.includes('?') ? '&' : '?'}token=${token}`;

--- a/src/modules/auth/auth.controller.js
+++ b/src/modules/auth/auth.controller.js
@@ -34,7 +34,8 @@ const authController = {
 
   async forgotPassword(req, res, next) {
     try {
-      const result = await authService.requestPasswordReset(req.body.identifier);
+      const { identifier, returnUrl } = req.body;
+      const result = await authService.requestPasswordReset(identifier, returnUrl);
       res.status(200).json(result);
     } catch (err) {
       next(err);
@@ -63,12 +64,12 @@ const authController = {
   async verifyResetToken(req, res, next) {
     try {
       const token = req.query['token'];
+      const returnUrl = req.query['returnUrl'];
       await authService.verifyResetToken(token); // Valida internamente
 
       const { env } = require('../../config/env');
 
-      // Intentamos usar la URL específica de reset, sino el scheme base
-      const deepLinkBase = env.MOBILE_RESET_PASSWORD_URL || 'udesamigos://ResetPassword';
+      const deepLinkBase = returnUrl || 'udesamigos://reset-password';
       // Si el link base ya contiene el esquema y el path, solo agregamos el token
       const deepLink = `${deepLinkBase}${deepLinkBase.includes('?') ? '&' : '?'}token=${token}`;
 

--- a/src/modules/auth/auth.schemas.js
+++ b/src/modules/auth/auth.schemas.js
@@ -14,6 +14,7 @@ const forgotPasswordSchema = z.object({
   identifier: z
     .string({ required_error: 'El email o nombre de usuario es obligatorio' })
     .min(1, 'El email o nombre de usuario es obligatorio'),
+  returnUrl: z.string().url().optional(),
 });
 
 const resetPasswordSchema = z.object({

--- a/src/modules/auth/auth.service.js
+++ b/src/modules/auth/auth.service.js
@@ -103,7 +103,7 @@ const authService = {
     };
   },
 
-  async requestPasswordReset(identifier) {
+  async requestPasswordReset(identifier, returnUrl) {
     // CA.4: find by email or username, always return same message
     let user = await userRepository.findByEmail(identifier.toLowerCase());
     if (!user) {
@@ -132,7 +132,7 @@ const authService = {
     await userRepository.updatePasswordResetToken(user.id, token, expiresAt);
     await userRepository.updateLastResetRequest(user.id);
 
-    sendResetPasswordEmail(user.email, token).catch((err) =>
+    sendResetPasswordEmail(user.email, token, returnUrl).catch((err) =>
       console.error('Failed to send reset password email:', err)
     );
 

--- a/tests/unit/auth.service.test.js
+++ b/tests/unit/auth.service.test.js
@@ -295,7 +295,7 @@ describe('authService.requestPasswordReset', () => {
     await authService.requestPasswordReset('test@example.com');
     await Promise.resolve();
 
-    expect(sendResetPasswordEmail).toHaveBeenCalledWith('test@example.com', 'reset-token-uuid');
+    expect(sendResetPasswordEmail).toHaveBeenCalledWith('test@example.com', 'reset-token-uuid', undefined);
   });
 
   it('no falla si el envío del email falla', async () => {


### PR DESCRIPTION
Arreglo bug de deeplink.
El deeplink lo armaba users a partir de la variable de entorno con la IP del servidor de frontend.
Ahora con variables de entorno en el deploy eso es inviable.
Solucion: Que el frontend le pase en el body el deeplink con su direccion para que el backend pueda armar correctamente el mail con la redireccion.